### PR TITLE
add 'explain' support to rogue

### DIFF
--- a/src/main/scala/com/foursquare/rogue/Query.scala
+++ b/src/main/scala/com/foursquare/rogue/Query.scala
@@ -149,6 +149,9 @@ class BaseQuery[M <: MongoRecord[M], R, Ord, Sel, Lim, Sk](
     val transformer = (xs: List[_]) => (xs(0).asInstanceOf[F1], xs(1).asInstanceOf[F2], xs(2).asInstanceOf[F3], xs(3).asInstanceOf[F4])
     new BaseQuery(meta, lim, sk, condition, order, Some(MongoSelect(fields, transformer)))
   }
+  def explain = {
+    QueryExecutor.explain("find", this)
+  }
 }
 
 class BaseEmptyQuery[M <: MongoRecord[M], R, Ord, Sel, Lim, Sk] extends BaseQuery[M, R, Ord, Sel, Lim, Sk](null.asInstanceOf[M with MongoMetaRecord[M]], None, None, null.asInstanceOf[AndCondition], None, None) {
@@ -174,6 +177,7 @@ class BaseEmptyQuery[M <: MongoRecord[M], R, Ord, Sel, Lim, Sk] extends BaseQuer
   }
 
   override def bulkDelete_!!()(implicit ev1: Sel =:= Unselected, ev2: Lim =:= Unlimited, ev3: Sk =:= Unskipped): Unit = ()
+  override def explain = "{}"
   override def toString = "empty query"
   override def signature = "empty query"
 


### PR DESCRIPTION
Usage:

scala> Venue.where(_.legacyid eqs 128530).explain
[2011-05-03 19:32:54,661] [run-main] DEBUG MongoQueryLogger - Mongo venues.find({ "legid" : 128530})
res1: String = { "cursor" : "BtreeCursor legid_1" , "nscanned" : 1 , "nscannedObjects" : 1 , "n" : 1 , "millis" : 0 , "nYields" : 0 , "nChunkSkips" : 0 , "isMultiKey" : false , "indexOnly" : false , "indexBounds" : { "legid" : [ [ 128530 , 128530]]} , "allPlans" : [ { "cursor" : "BtreeCursor legid_1" , "indexBounds" : { "legid" : [ [ 128530 , 128530]]}}] , "oldPlan" : { "cursor" : "BtreeCursor legid_1" , "indexBounds" : { "legid" : [ [ 128530 , 128530]]}}}

scala> prettyJson(res1)  
res2: String = 
{
  "cursor":"BtreeCursor legid_1",
  "nscanned":1,
  "nscannedObjects":1,
  "n":1,
  "millis":0,
  "nYields":0,
  "nChunkSkips":0,
  "isMultiKey":false,
  "indexOnly":false,
  "indexBounds":{
    "legid":[[128530,128530]]
  },
  "allPlans":[{
    "cursor":"BtreeCursor legid_1",
    "indexBounds":{
      "legid":[[128530,128530]]
    }
  }],
  "oldPlan":{
    "cursor":"BtreeCursor legid_1",
    "indexBounds":{
      "legid":[[128530,128530]]
    }
  }
}
