### PR TITLE
Implementation of $maxScan + $comment

### DIFF
--- a/src/main/scala/com/foursquare/rogue/MongoHelpers.scala
+++ b/src/main/scala/com/foursquare/rogue/MongoHelpers.scala
@@ -178,6 +178,8 @@ object MongoHelpers {
         ord.foreach(o => str.append(".sort("+o+")"))
         query.sk.foreach(sk => str.append(".skip("+sk+")"))
         query.lim.foreach(l => str.append(".limit("+l+")"))
+        query.maxScan.foreach(m => str.append(".addSpecial(\"$maxScan\", "+m+")"))
+        query.comment.foreach(c => str.append(".addSpecial(\"$comment\", \""+c+"\")"))
         str.toString
       }
       
@@ -188,6 +190,8 @@ object MongoHelpers {
 
           val cursor = coll.find(cnd, sel).limit(query.lim getOrElse 0).skip(query.sk getOrElse 0)
           ord.foreach(cursor sort _)
+          query.maxScan.foreach(cursor addSpecial("$maxScan", _))
+          query.comment.foreach(cursor addSpecial("$comment", _))
           f(cursor)
         }
       }

--- a/src/main/scala/com/foursquare/rogue/Rogue.scala
+++ b/src/main/scala/com/foursquare/rogue/Rogue.scala
@@ -17,7 +17,7 @@ trait Rogue {
   type EmptyQuery[T <: MongoRecord[T]] = BaseEmptyQuery[T, T, Unordered, Unselected, Unlimited, Unskipped]
   type ModifyQuery[T <: MongoRecord[T]] = AbstractModifyQuery[T]
 
-  implicit def metaRecordToQueryBuilder[M <: MongoRecord[M]](rec: M with MongoMetaRecord[M]) = BaseQuery[M, M, Unordered, Unselected, Unlimited, Unskipped](rec, None, None, AndCondition(Nil), None, None)
+  implicit def metaRecordToQueryBuilder[M <: MongoRecord[M]](rec: M with MongoMetaRecord[M]) = BaseQuery[M, M, Unordered, Unselected, Unlimited, Unskipped](rec, None, None, None, None, AndCondition(Nil), None, None)
   implicit def metaRecordToModifyQuery[M <: MongoRecord[M]](rec: M with MongoMetaRecord[M]) = BaseModifyQuery(metaRecordToQueryBuilder(rec), MongoModify(Nil))
   implicit def queryBuilderToModifyQuery[M <: MongoRecord[M]](query: AbstractQuery[M, M, Unordered, Unselected, Unlimited, Unskipped]) = {
     query match {


### PR DESCRIPTION
As discussed, it's a little awkward to have maxScan() and comment() work on functions (e.g. count()) where it does not work. Still, this reflects a shortcoming of DBCursor/Mongo so I'm fine having this no-op on all other functions instead of find(). Additional feedback welcome though.
