### PR TITLE
2.9.0 and 2.9.0-1 build support

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -4,6 +4,6 @@ project.organization=com.foursquare
 project.name=rogue
 sbt.version=0.7.5
 project.version=1.0.14-SNAPSHOT
-build.scala.versions=2.8.1 2.8.0
+build.scala.versions=2.8.1 2.9.0-1 2.9.0 2.8.0
 project.initialize=false
 lift.version=2.4-SNAPSHOT

--- a/project/build/RogueProject.scala
+++ b/project/build/RogueProject.scala
@@ -17,7 +17,7 @@ class RogueProject(info: ProjectInfo) extends DefaultProject(info) with Credenti
   // Java Libraries
   lazy val specsVersion = buildScalaVersion match {
     case "2.8.0" => "1.6.5"
-    case _       => "1.6.7.2"
+    case _       => "1.6.8"
   }
   val junit = "junit"                    % "junit" % "4.8.2"      % "test" withSources()
   val specs = "org.scala-tools.testing" %% "specs" % specsVersion % "test" withSources()


### PR DESCRIPTION
Hi,

I added build support for Scala 2.9.0 and 2.9.0-1. This aligns Rogue with what Lift is building with.

Tim
