### PR TITLE
Added jsWhere, jsWhereOpt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Release Notes
 
+# 1.0.20
+
+- sbt 0.10.0
+- raw access do BasicDBObjectBuilder in query builder
+- fixed some broken logging
+
 # 1.0.19
 
 - whereOpt support: Venue.whereOpt(uidOpt)(_.userid eqs _)

--- a/README.md
+++ b/README.md
@@ -37,12 +37,15 @@ Because Rogue is designed to work with several versions of lift-mongodb-record (
 you'll want to declare your dependency on Rogue as `intransitive` and declare an explicit dependency
 on the version of Lift you want to target. In sbt, that would look like the following: 
 
-    val rogue           = "com.foursquare" %% "rogue"               % "1.0.19" intransitive()
+    val rogue           = "com.foursquare" %% "rogue"               % "1.0.20" intransitive()
     val liftMongoRecord = "net.liftweb"    %% "lift-mongodb-record" % "2.4-M2"
 
 You can substitute "2.4-M2" for whatever version of Lift you are using. Rogue has been used in
 production against Lift 2.2 and 2.4-M2. If you encounter problems using Rogue with other versions
 of Lift, please let us know.
+
+Join the [rogue-users google group](http://groups.google.com/group/rogue-users) for help, bug reports,
+feature requests, and general discussion on Rogue.
 
 ## More Examples
 
@@ -84,15 +87,20 @@ for "findAndModify" query objects
 
 ## Releases
 
-The latest release is 1.0.19. See the [changelog](https://github.com/foursquare/rogue/blob/master/CHANGELOG.md) for more details.
+The latest release is 1.0.20. See the [changelog](https://github.com/foursquare/rogue/blob/master/CHANGELOG.md) for more details.
 
-New in 1.0.19:
+New in 1.0.20:
+
+- sbt 0.10.0
+- raw access do BasicDBObjectBuilder in the query builder, to let you do things like this:
+
+    Venue where (_.mayor eqs 1) raw (_.add("$where", "this.a > 3"))
+
+- fixed some broken logging
+
+Lots of new features in 1.0.18 and 1.0.19!:
 
 - whereOpt support: Venue.whereOpt(uidOpt)(_.userid eqs _)
-- Pass the query signature to the logging hook
-
-Lots of new features in 1.0.18!:
-
 - findAndModify support
 - $or query support
 - efficient .exists query method (thanks Jorge!)

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "rogue"
 
-version := "1.0.20-SNAPSHOT"
+version := "1.0.21-SNAPSHOT"
 
 organization := "com.foursquare"
 

--- a/src/main/scala/com/foursquare/rogue/MongoHelpers.scala
+++ b/src/main/scala/com/foursquare/rogue/MongoHelpers.scala
@@ -20,21 +20,30 @@ object MongoHelpers {
   object MongoBuilder {
     def buildCondition(cond: AndCondition, signature: Boolean = false, jsWhere: Option[String] = None): DBObject = {
       val builder = BasicDBObjectBuilder.start
-      (cond.clauses.groupBy(_.fieldName)
-              .toList
-              .sortBy { case (fieldName, _) => -cond.clauses.indexWhere(_.fieldName == fieldName) }
-              .foreach { case (name, cs) =>
+      val (rawClauses, safeClauses) = cond.clauses.partition(_.isInstanceOf[RawQueryClause])
+
+      // Normal clauses
+      safeClauses.groupBy(_.fieldName).toList
+          .sortBy{ case (fieldName, _) => -cond.clauses.indexWhere(_.fieldName == fieldName) }
+          .foreach{ case (name, cs) => {
         // Equality clauses look like { a : 3 }
         // but all other clauses look like { a : { $op : 3 }}
         // and can be chained like { a : { $gt : 2, $lt: 6 }}.
         // So if there is any equality clause, apply it (only) to the builder;
         // otherwise, chain the clauses.
-        cs.filter(_.isInstanceOf[EqClause[_]]).headOption.map(_.extend(builder, signature)).getOrElse {
-          builder.push(name)
-          cs.foreach(_.extend(builder, signature))
-          builder.pop
+        cs.filter(_.isInstanceOf[EqClause[_]]).headOption match {
+          case Some(eqClause) => eqClause.extend(builder, signature)
+          case None => {
+            builder.push(name)
+            cs.foreach(_.extend(builder, signature))
+            builder.pop
+          }
         }
-      })
+      }}
+
+      // Raw clauses
+      rawClauses.foreach(_.extend(builder, signature))
+
       // Optional $or clause (only one per "and" chain)
       cond.orCondition.foreach(or => builder.add("$or", QueryHelpers.list(or.conditions.map(buildCondition(_, signature = false)))))
       // Optional $where clause (only one per query)
@@ -151,7 +160,8 @@ object MongoHelpers {
 
       validator.validateQuery(query)
       val cnd = buildCondition(query.condition)
-      runCommand(query.toString, query){
+      val description = buildQueryString(operation, query)
+      runCommand(description, query){
         f(cnd)
       }
     }

--- a/src/main/scala/com/foursquare/rogue/QueryClause.scala
+++ b/src/main/scala/com/foursquare/rogue/QueryClause.scala
@@ -13,9 +13,8 @@ object IndexBehavior extends Enumeration {
 }
 
 class QueryClause[V](val fieldName: String, conditions: (CondOps.Value, V)*) {
-  def extend(q: BasicDBObjectBuilder, signature: Boolean): BasicDBObjectBuilder = {
+  def extend(q: BasicDBObjectBuilder, signature: Boolean): Unit = {
     conditions foreach { case (op, v) => q.add(op.toString, if (signature) 0 else v) }
-    q
   }
   lazy val actualIndexBehavior = conditions.head._1 match {
     case CondOps.All | CondOps.In => IndexBehavior.Index
@@ -27,14 +26,22 @@ class QueryClause[V](val fieldName: String, conditions: (CondOps.Value, V)*) {
   def withExpectedIndexBehavior(b: IndexBehavior.Value) = new QueryClause(fieldName, conditions: _*) { override val expectedIndexBehavior = b }
 }
 
+class RawQueryClause(f: BasicDBObjectBuilder => Unit) extends QueryClause("raw") {
+  override def extend(q: BasicDBObjectBuilder, signature: Boolean): Unit = {
+    f(q)
+  }
+  override lazy val actualIndexBehavior = IndexBehavior.DocumentScan
+  override val expectedIndexBehavior = IndexBehavior.DocumentScan
+}
+
 class EmptyQueryClause[V](fieldName: String) extends QueryClause[V](fieldName) {
-  override def extend(q: BasicDBObjectBuilder, signature: Boolean): BasicDBObjectBuilder = new BasicDBObjectBuilder
+  override def extend(q: BasicDBObjectBuilder, signature: Boolean): Unit = {}
   override lazy val actualIndexBehavior = IndexBehavior.Index
   override def withExpectedIndexBehavior(b: IndexBehavior.Value) = new EmptyQueryClause[V](fieldName) { override val expectedIndexBehavior = b }
 }
 
 class EqClause[V](fieldName: String, value: V) extends QueryClause[V](fieldName) {
-  override def extend(q: BasicDBObjectBuilder, signature: Boolean): BasicDBObjectBuilder = {
+  override def extend(q: BasicDBObjectBuilder, signature: Boolean): Unit = {
     q.add(fieldName, if (signature) 0 else value)
   }
   override lazy val actualIndexBehavior = IndexBehavior.Index
@@ -42,7 +49,7 @@ class EqClause[V](fieldName: String, value: V) extends QueryClause[V](fieldName)
 }
 
 class WithinCircleClause[V](fieldName: String, lat: Double, lng: Double, radius: Double) extends QueryClause(fieldName) {
-  override def extend(q: BasicDBObjectBuilder, signature: Boolean): BasicDBObjectBuilder = {
+  override def extend(q: BasicDBObjectBuilder, signature: Boolean): Unit = {
     val value = if (signature) 0 else QueryHelpers.list(List(QueryHelpers.list(List(lat, lng)), radius))
     q.push("$within").add("$center", value).pop
   }
@@ -51,7 +58,7 @@ class WithinCircleClause[V](fieldName: String, lat: Double, lng: Double, radius:
 }
 
 class WithinBoxClause[V](fieldName: String, lat1: Double, lng1: Double, lat2: Double, lng2: Double) extends QueryClause(fieldName) {
-  override def extend(q: BasicDBObjectBuilder, signature: Boolean): BasicDBObjectBuilder = {
+  override def extend(q: BasicDBObjectBuilder, signature: Boolean): Unit = {
     val value = if (signature) 0 else {
       QueryHelpers.list(List(QueryHelpers.list(lat1, lng1), QueryHelpers.list(lat2, lng2)))
     }
@@ -62,14 +69,13 @@ class WithinBoxClause[V](fieldName: String, lat1: Double, lng1: Double, lat2: Do
 }
 
 class ModifyClause[V](val operator: ModOps.Value, fields: (String, V)*) {
-  def extend(q: BasicDBObjectBuilder): BasicDBObjectBuilder = {
+  def extend(q: BasicDBObjectBuilder): Unit = {
     fields foreach { case (name, value) => q.add(name, value) }
-    q
   }
 }
 
 class ModifyAddEachClause[V](fieldName: String, values: Traversable[V]) extends ModifyClause[V](ModOps.AddToSet) {
-  override def extend(q: BasicDBObjectBuilder): BasicDBObjectBuilder = {
+  override def extend(q: BasicDBObjectBuilder): Unit = {
     q.push(fieldName).add("$each", QueryHelpers.list(values)).pop
   }
 }

--- a/src/test/scala/com/foursquare/rogue/QueryTest.scala
+++ b/src/test/scala/com/foursquare/rogue/QueryTest.scala
@@ -272,6 +272,9 @@ class QueryTest extends SpecsMatchers {
     Venue where (_.mayor eqs 1) skip(10)           toString() must_== """db.venues.find({ "mayor" : 1}).skip(10)"""
     Venue where (_.mayor eqs 1) skipOpt(Some(10))  toString() must_== """db.venues.find({ "mayor" : 1}).skip(10)"""
     Venue where (_.mayor eqs 1) skipOpt(None)      toString() must_== """db.venues.find({ "mayor" : 1})"""
+      
+    // raw query clauses
+    Venue where (_.mayor eqs 1) raw (_.add("$where", "this.a > 3")) toString() must_== """db.venues.find({ "mayor" : 1 , "$where" : "this.a > 3"})"""      
 
     // javascript $where clause
     Venue jsWhere("function() { return true; }") toString() must_== """db.venues.find({ "$where" : "function() { return true; }"})"""


### PR DESCRIPTION
Hi Jason,

Let me know if this implementation is helpful, or if you want to take an entirely different tack.

We treated the js $where as an optional string at the top-level of the query. Following the mongo syntax, we generate the clause after the top-level AndCondition in MongoHelpers.buildCondition.

Update: Using this approach, vs a generic "raw" clause interface, one can use phantom types to ensure that there is at most a single $where clause, etc. We didn't finish the phantom types yet, but wanted to get this pull request submitted so that you could review asap. [update 2: we did finish the phantom types, with a test that duplicate $where is prevented]

Regards,
-Marc
