### PR TITLE
Add hook for intercepting and transforming queries right before sending request to mongodb. 

### DIFF
--- a/src/main/scala/com/foursquare/rogue/QueryHelpers.scala
+++ b/src/main/scala/com/foursquare/rogue/QueryHelpers.scala
@@ -66,6 +66,22 @@ object QueryHelpers {
 
   var validator: QueryValidator = NoopQueryValidator
 
+  trait QueryTransformer { 
+    def transformQuery[M <: MongoRecord[M]](query: BaseQuery[M, _, _, _, _, _, _]): BaseQuery[M, _, _, _, _, _, _]
+    def transformModify[M <: MongoRecord[M]](modify: BaseModifyQuery[M]): BaseModifyQuery[M]
+    def transformFindAndModify[M <: MongoRecord[M], R](modify: BaseFindAndModifyQuery[M, R]): BaseFindAndModifyQuery[M, R]
+  }
+
+  class DefaultQueryTransformer extends QueryTransformer { 
+    override def transformQuery[M <: MongoRecord[M]](query: BaseQuery[M, _, _, _, _, _, _]): BaseQuery[M, _, _, _, _, _, _] = { query }
+    override def transformModify[M <: MongoRecord[M]](modify: BaseModifyQuery[M]): BaseModifyQuery[M] = { modify }
+    override def transformFindAndModify[M <: MongoRecord[M], R](modify: BaseFindAndModifyQuery[M, R]): BaseFindAndModifyQuery[M, R] = { modify }
+  }
+
+  object NoopQueryTransformer extends DefaultQueryTransformer
+
+  var transformer: QueryTransformer = NoopQueryTransformer
+
   def makeJavaList[T](sl: Traversable[T]): java.util.List[T] = {
     val list = new java.util.ArrayList[T]()
     for (id <- sl) list.add(id)


### PR DESCRIPTION
This change adds support for callback mechanism such that right before requests are sent to
mongodb, it gets the opportunity to transform the request. For instance, it can enforce the
limit (number of documents to return) or automatically append comments to each request, etc.
