### PR TITLE
Added index checker to allow clients to ensure that the indexes needed by their query really do exist.

### DIFF
--- a/src/main/scala/com/foursquare/rogue/IndexChecker.scala
+++ b/src/main/scala/com/foursquare/rogue/IndexChecker.scala
@@ -1,0 +1,211 @@
+// Copyright 2011 Foursquare Labs Inc. All Rights Reserved.
+package com.foursquare.rogue
+
+import scala.collection.immutable.ListMap
+import net.liftweb.common.Loggable
+import net.liftweb.mongodb.record._
+import net.liftweb.util.Props
+
+/**
+ * A trait that represents the fact that a record type includes a list
+ * of the indexes that exist in MongoDB for that type.
+ */
+trait IndexedRecord[M <: MongoRecord[M]] {
+  val mongoIndexList: List[MongoIndex[_]] = List()
+}
+
+/**
+ * A container for query-type shorthands.
+ */
+trait MongoQueryTypes {
+  type GenericQuery[M <: MongoRecord[M], R] = AbstractQuery[M, R, _, _, _, _, _]
+  type GenericBaseQuery[M <: MongoRecord[M], R] = BaseQuery[M, R, _, _, _, _, _]
+}
+
+/**
+ * A utility object which provides the capability to verify if the set of indexes that
+ * actually exist for a MongoDB collection match the indexes that are expected by
+ * a query.
+ */
+object MongoIndexChecker extends Loggable with MongoQueryTypes {
+
+  /**
+   * Flattens an arbitrary query into DNF - that is, into a list of query alternatives
+   * implicitly joined by logical "or", where each of alternatives consists of a list of query
+   * clauses implicitly joined by "and".
+   */
+  def flattenCondition(condition: MongoHelpers.AndCondition): List[List[QueryClause[_]]] = {
+    condition.orCondition match {
+      case None => List(condition.clauses)
+      case Some(or) => for {
+        subconditions <- or.conditions
+        subclauses <- flattenCondition(subconditions)
+      } yield (condition.clauses ++ subclauses)
+    }
+  }
+
+  def normalizeCondition(condition: MongoHelpers.AndCondition): List[List[QueryClause[_]]] = {
+    flattenCondition(condition).map(_.filter(_.expectedIndexBehavior != IndexBehavior.DocumentScan))
+  }
+
+  /**
+   * Retrieves the list of indexes declared for the record type associated with a
+   * query. If the record type doesn't declare any indexes, then returns an empty list.
+   * @param query the query
+   * @return the list of indexes, or an empty list.
+   */
+  def getIndexes(query: GenericBaseQuery[_, _]): List[MongoIndex[_]] = {
+    val queryMetaRecord = query.meta.asInstanceOf[MongoRecord[_]]
+    if (queryMetaRecord.isInstanceOf[IndexedRecord[_]]) {
+      queryMetaRecord.asInstanceOf[IndexedRecord[_]].mongoIndexList
+    } else {
+      List()
+    }
+  }
+
+  /**
+   * Verifies that the indexes expected for a query actually exist in the mongo database.
+   * Logs an error via {@link QueryLogger#logIndexMismatch} if there is no
+   * matching index. Clients may choose to signal errors by overriding
+   * logIndexMismatch.
+   * @param query the query being validated.
+   * @return true if the required indexes are found, false otherwise.
+   */
+  def validateIndexExpectations(query: GenericBaseQuery[_, _]): Boolean = {
+    val indexes = getIndexes(query)
+    validateIndexExpectations(query, indexes)
+  }
+
+  /**
+   * Verifies that the indexes expected for a query actually exist in the mongo database.
+   * Signals an error if the indexes don't fulfull the expectations. ({@see #throwErrors})
+   * This version of validaateIndexExpectations is intended for use in cases where
+   * the indexes are not explicitly declared in the class, but the caller knows what set
+   * of indexes are actually available.
+   * @param query the query being validated.
+   * @param indexes a list of the indexes
+   * @return true if the required indexes are found, false otherwise.
+   */
+  def validateIndexExpectations(query: GenericBaseQuery[_, _], indexes: List[MongoIndex[_]]): Boolean = {
+    val baseConditions = normalizeCondition(query.condition);
+    val conditions = baseConditions.map(_.filter(_.expectedIndexBehavior != IndexBehavior.DocumentScan))
+
+    conditions.forall(clauses => {
+      clauses.forall(clause => {
+        // DocumentScan expectations have been filtered out at this point.
+        // We just have to worry about expectations being more optimistic than actual.
+        val badExpectations = List(
+          IndexBehavior.Index -> List(IndexBehavior.PartialIndexScan, IndexBehavior.IndexScan,IndexBehavior.DocumentScan),
+          IndexBehavior.IndexScan -> List(IndexBehavior.DocumentScan)
+        )
+        badExpectations.forall{ case (expectation, badActual) => {
+          if (clause.expectedIndexBehavior == expectation &&
+              badActual.exists(_ == clause.actualIndexBehavior)) {
+	    signalError(
+                "Query is expecting %s on %s but actual behavior is %s. query = %s" format
+                (clause.expectedIndexBehavior, clause.fieldName, clause.actualIndexBehavior, query.toString))
+          } else true
+        }}
+      })
+    })
+  }
+
+  /**
+   * Verifies that the index expected by a query both exists, and will be used by MongoDB
+   * to execute that query. (Due to vagaries of the MongoDB implementation, sometimes a
+   * conceptually usable index won't be found.)
+   * @param query the query
+   * @param the query clauses in DNF form.
+   */
+  def validateQueryMatchesSomeIndex(query: GenericBaseQuery[_, _]): Boolean = {
+    val indexes = getIndexes(query)
+    validateQueryMatchesSomeIndex(query, indexes)
+  }
+
+  /**
+   * Verifies that the index expected by a query both exists, and will be used by MongoDB
+   * to execute that query. (Due to vagaries of the MongoDB implementation, sometimes a
+   * conceptually usable index won't be found.)
+   * @param query the query
+   * @param indexes the list of indexes that exist in the database
+   * @param the query clauses in DNF form.
+   */
+  def validateQueryMatchesSomeIndex(query: GenericBaseQuery[_, _], indexes: List[MongoIndex[_]]) = {
+    val conditions = normalizeCondition(query.condition)
+    lazy val indexString = indexes.map(idx => "{%s}".format(idx.toString())).mkString(", ")
+    conditions.forall(clauses => {
+      clauses.isEmpty || matchesUniqueIndex(clauses) ||
+          indexes.exists(idx => matchesIndex(idx.asListMap.keys.toList, clauses)) ||
+          signalError("Query does not match an index! query: %s, indexes: %s" format (
+              query.toString, indexString))
+    })
+  }
+
+  private def matchesUniqueIndex(clauses: List[QueryClause[_]]) = {
+    // Special case for overspecified queries matching on the _id field.
+    // TODO: Do the same for any overspecified query exactly matching a unique index.
+    clauses.exists(clause => clause.fieldName == "_id" && clause.actualIndexBehavior == IndexBehavior.Index)
+  }
+
+  private def matchesIndex(index: List[String],
+                           clauses: List[QueryClause[_]]) = {
+    // Unless explicitly hinted, MongoDB will only use an index if the first
+    // field in the index matches some query field.
+    clauses.exists(_.fieldName == index.head) &&
+        matchesCompoundIndex(index, clauses, scanning = false)
+  }
+
+  /**
+   * Matches a compound index against a list of query clauses, verifying that
+   * each query clause has its index expectations matched by a field of the
+   * index.
+   * @param index the index to be checked.
+   * @param clauses a list of query clauses joined by logical "and".
+   * @return true if every clause of the query is matched by a field of the
+   *   index; false otherwise.
+   */
+  private def matchesCompoundIndex(index: List[String],
+                                   clauses: List[QueryClause[_]],
+				   scanning: Boolean): Boolean = {
+    if (clauses.isEmpty) {
+      // All of the clauses have been matched to an index field. We are done!
+      true
+    } else {
+      index match {
+        case Nil => {
+          // Oh no! The index is exhausted but we still have clauses to match.
+          false
+        }
+        case field :: rest => {
+          val (matchingClauses, remainingClauses) = clauses.partition(_.fieldName == field)
+          matchingClauses match {
+            case matchingClause :: _ => {
+              // If a previous field caused a scan, this field must scan too.
+              val expectationOk = !scanning || matchingClause.expectedIndexBehavior == IndexBehavior.IndexScan
+              // If this field causes a scan, later fields must scan too.
+              val nowScanning = scanning ||
+                  matchingClause.actualIndexBehavior == IndexBehavior.IndexScan ||
+                  matchingClause.actualIndexBehavior == IndexBehavior.PartialIndexScan
+              expectationOk && matchesCompoundIndex(rest, remainingClauses, scanning = nowScanning)
+            }
+            case Nil => {
+              // We can skip a field in the index, but everything after it must scan.
+              matchesCompoundIndex(rest, remainingClauses, scanning = true)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Utility method that allows us to signal an error from inside of a disjunctive expression.
+   * e.g., "blah || blah || black || signalError(....)".
+   *
+   * @param msg a message string describing the error.
+   */
+  private def signalError(msg : String) : Boolean = {
+    QueryHelpers.logger.logIndexMismatch("Indexing error: " + msg)
+    false
+  }
+}

--- a/src/main/scala/com/foursquare/rogue/Indexes.scala
+++ b/src/main/scala/com/foursquare/rogue/Indexes.scala
@@ -15,6 +15,9 @@ case class IndexModifier(value: Any)
 
 trait MongoIndex[R <: MongoRecord[R]] {
   def asListMap: ListMap[String, Any]
+
+  override def toString() =
+    asListMap.map(fld => "%s:%s".format(fld._1, fld._2)).mkString(", ")
 }
 
 case class MongoIndex1[R <: MongoRecord[R],

--- a/src/main/scala/com/foursquare/rogue/QueryHelpers.scala
+++ b/src/main/scala/com/foursquare/rogue/QueryHelpers.scala
@@ -34,12 +34,14 @@ object QueryHelpers {
   trait QueryLogger {
     def log(msg: => String, signature: => String, timeMillis: Long): Unit = log(msg, timeMillis)
     def log(msg: => String, timeMillis: Long): Unit
+    def logIndexMismatch(msg: => String)
     def warn(msg: => String): Unit
   }
 
   class DefaultQueryLogger extends QueryLogger {
     override def log(msg: => String, timeMillis: Long) {}
     override def warn(msg: => String) {}
+    override def logIndexMismatch(msg: => String) { }
   }
 
   object NoopQueryLogger extends DefaultQueryLogger
@@ -66,13 +68,13 @@ object QueryHelpers {
 
   var validator: QueryValidator = NoopQueryValidator
 
-  trait QueryTransformer { 
+  trait QueryTransformer {
     def transformQuery[M <: MongoRecord[M]](query: BaseQuery[M, _, _, _, _, _, _]): BaseQuery[M, _, _, _, _, _, _]
     def transformModify[M <: MongoRecord[M]](modify: BaseModifyQuery[M]): BaseModifyQuery[M]
     def transformFindAndModify[M <: MongoRecord[M], R](modify: BaseFindAndModifyQuery[M, R]): BaseFindAndModifyQuery[M, R]
   }
 
-  class DefaultQueryTransformer extends QueryTransformer { 
+  class DefaultQueryTransformer extends QueryTransformer {
     override def transformQuery[M <: MongoRecord[M]](query: BaseQuery[M, _, _, _, _, _, _]): BaseQuery[M, _, _, _, _, _, _] = { query }
     override def transformModify[M <: MongoRecord[M]](modify: BaseModifyQuery[M]): BaseModifyQuery[M] = { modify }
     override def transformFindAndModify[M <: MongoRecord[M], R](modify: BaseFindAndModifyQuery[M, R]): BaseFindAndModifyQuery[M, R] = { modify }

--- a/src/test/scala/com/foursquare/rogue/IndexCheckerTest.scala
+++ b/src/test/scala/com/foursquare/rogue/IndexCheckerTest.scala
@@ -1,0 +1,192 @@
+// Copyright 2011 Foursquare Labs Inc. All Rights Reserved.
+
+package com.foursquare.rogue
+
+import com.foursquare.rogue.Rogue._
+import net.liftweb.mongodb.record._
+import net.liftweb.mongodb.record.field._
+import net.liftweb.record._
+import net.liftweb.record.field.{BooleanField, IntField}
+import scala.collection.immutable.ListMap
+
+import org.bson.types.ObjectId
+import org.joda.time.DateTime
+import org.junit._
+import org.specs.SpecsMatchers
+
+
+class TestModel extends MongoRecord[TestModel] with MongoId[TestModel] {
+  def meta = TestModel
+  object a extends IntField(this)
+  object b extends IntField(this)
+  object c extends IntField(this)
+  object d extends IntField(this)
+  object m extends MongoMapField[TestModel, Int](this)
+  object n extends MongoMapField[TestModel, Int](this)
+  object ll extends MongoCaseClassField[TestModel, LatLong](this)
+}
+
+object TestModel extends TestModel with MongoMetaRecord[TestModel] with IndexedRecord[TestModel] {
+  override def collectionName = "model"
+
+  override val mongoIndexList = List(
+    TestModel.index(_._id, Asc),
+    TestModel.index(_.a, Asc, _.b, Asc, _.c, Asc),
+    TestModel.index(_.m, Asc, _.a, Asc),
+    TestModel.index(_.ll, TwoD, _.b, Asc))
+}
+
+class MongoIndexCheckerTest extends SpecsMatchers with MongoQueryTypes {
+
+  @Test
+  def testIndexExpectations {
+    def test(query: GenericQuery[_, _]) = {
+      val q = query.asInstanceOf[GenericBaseQuery[_, _]]
+      MongoIndexChecker.validateIndexExpectations(q)
+    }
+
+    def yes(query: GenericQuery[_, _]) =
+      test(query) must beTrue
+    def no(query: GenericQuery[_, _]) =
+      test(query) must beFalse
+
+    yes(TestModel where (_.a eqs 1))
+    yes(TestModel iscan (_.a eqs 1))
+    yes(TestModel scan  (_.a eqs 1))
+
+    no(TestModel where (_.a > 1))
+
+    yes(TestModel iscan (_.a > 1))
+    yes(TestModel scan  (_.a > 1))
+
+    no(TestModel where (_.a neqs 1))
+    yes(TestModel iscan (_.a neqs 1))
+    yes(TestModel scan  (_.a neqs 1))
+
+    no(TestModel where (_.a exists true))
+    no(TestModel iscan (_.a exists true))
+    yes(TestModel scan  (_.a exists true))
+
+    no(TestModel where (_.ll near (1.0, 2.0, Degrees(1.0))))
+    yes(TestModel iscan (_.ll near (1.0, 2.0, Degrees(1.0))))
+    yes(TestModel scan (_.ll near (1.0, 2.0, Degrees(1.0))))
+
+    // $or queries
+    yes(TestModel where (_.a eqs 1) or (_.where(_.b eqs 2), _.where(_.b eqs 2)))
+    no(TestModel where (_.a eqs 1) or (_.where(_.b > 2), _.where(_.b < 2)))
+    yes(TestModel where (_.a eqs 1) or (_.iscan(_.b > 2), _.iscan(_.b < 2)))
+    yes(TestModel where (_.a eqs 1) or (_.scan(_.b > 2), _.scan(_.b < 2)))
+    no(TestModel where (_.a eqs 1) or (_.where(_.b exists true), _.where(_.b eqs 0)))
+    no(TestModel where (_.a eqs 1) or (_.iscan(_.b exists true), _.where(_.b eqs 0)))
+    yes(TestModel where (_.a eqs 1) or (_.scan(_.b exists true), _.where(_.b eqs 0)))
+  }
+
+  @Test
+  def testMatchesIndex {
+    def test(query: GenericQuery[_, _]) = {
+      val q = query.asInstanceOf[GenericBaseQuery[_, _]]
+      MongoIndexChecker.validateIndexExpectations(q) &&
+        MongoIndexChecker.validateQueryMatchesSomeIndex(q)
+    }
+
+    def yes(query: GenericQuery[_, _]) =
+      test(query) must beTrue
+
+    def no(query: GenericQuery[_, _]) =
+      test(query) must beFalse
+
+    yes(TestModel where (_.a eqs 1))
+    yes(TestModel where (_.a eqs 1) and (_.b eqs 2))
+    yes(TestModel where (_.a eqs 1) and (_.b eqs 2) and (_.c eqs 3))
+    yes(TestModel where (_.a eqs 1) and (_.c eqs 3) and (_.b eqs 2))
+
+    // Skip level
+    yes(TestModel where (_.a eqs 1) iscan (_.c eqs 3))
+    yes(TestModel where (_.a eqs 1) scan (_.c eqs 3))
+    no(TestModel where (_.a eqs 1) and (_.c eqs 3))
+
+    // Missing initial
+    yes(TestModel scan (_.b eqs 2))
+    no(TestModel where (_.b eqs 2))
+    no(TestModel iscan (_.b eqs 2))
+
+    // Range
+    yes(TestModel iscan (_.a > 1) iscan (_.b eqs 2))
+    yes(TestModel scan (_.a > 1) scan (_.b eqs 2))
+    no(TestModel where (_.a > 1) and (_.b eqs 2))
+    no(TestModel where (_.a > 1) iscan (_.b eqs 2))
+    yes(TestModel where (_.a eqs 1) and (_.b eqs 2) iscan (_.c > 3))
+
+    // Range placement
+    yes(TestModel where (_.a eqs 1) iscan (_.b eqs 2) iscan (_.c > 3))
+    yes(TestModel where (_.a eqs 1) iscan (_.b > 2) iscan (_.c eqs 3))
+    yes(TestModel iscan (_.a > 1) iscan (_.b eqs 2) iscan (_.c eqs 3))
+
+    // Double range
+    yes(TestModel iscan (_.a > 1) iscan (_.b > 2) iscan (_.c eqs 3))
+    no(TestModel where (_.a > 1) and (_.b > 2) and (_.c eqs 3))
+    no(TestModel where (_.a > 1) and (_.b > 2) iscan (_.c eqs 3))
+    no(TestModel where (_.a > 1) iscan (_.b > 2) iscan (_.c eqs 3))
+    no(TestModel where (_.a > 1) iscan (_.b > 2) and (_.c eqs 3))
+    yes(TestModel iscan (_.a > 1) scan (_.b > 2) scan (_.c eqs 3))
+    yes(TestModel iscan (_.a > 1) scan (_.b > 2) iscan (_.c eqs 3))
+    yes(TestModel where (_.a eqs 1) iscan (_.b > 2) iscan (_.c > 3))
+    no(TestModel where (_.a eqs 1) and (_.b > 2) iscan (_.c > 3))
+
+    // Unindexable
+    yes(TestModel scan (_.a exists true))
+    no(TestModel where (_.a exists true))
+    no(TestModel iscan (_.a exists true))
+
+    yes(TestModel scan (_.a exists true) scan (_.b eqs 3))
+    no(TestModel scan (_.a exists true) iscan (_.b eqs 3))
+
+    // Not in index
+    yes(TestModel where (_.a eqs 1) scan (_.d eqs 4))
+    no(TestModel where (_.a eqs 1) and (_.d eqs 4))
+    no(TestModel where (_.a eqs 1) iscan (_.d eqs 4))
+
+    // 2d indexes
+    yes(TestModel iscan (_.ll near (1.0, 2.0, Degrees(1.0))) iscan (_.b eqs 2))
+    no(TestModel where (_.ll near (1.0, 2.0, Degrees(1.0))) and (_.b eqs 2))
+    no(TestModel where (_.ll near (1.0, 2.0, Degrees(1.0))) iscan (_.b eqs 2))
+    no(TestModel iscan (_.ll near (1.0, 2.0, Degrees(1.0))) and (_.b eqs 2))
+    yes(TestModel iscan (_.ll near (1.0, 2.0, Degrees(1.0))) scan (_.c eqs 2))
+    no(TestModel iscan (_.ll near (1.0, 2.0, Degrees(1.0))) iscan (_.c eqs 2))
+
+    // Overspecifed queries
+    val id = new ObjectId
+    val d = new DateTime
+    yes(TestModel where (_._id eqs id) and (_.d eqs 4))
+    yes(TestModel where (_._id in List(id)) and (_.d eqs 4))
+    no(TestModel where (_._id after d) scan (_.d eqs 4))
+    no(TestModel iscan (_._id after d) iscan (_.d eqs 4))
+    yes(TestModel iscan (_._id after d) scan (_.d eqs 4))
+
+    // Multikeys
+    yes(TestModel scan (_.m at "foo" eqs 2))
+    no(TestModel where (_.m at "foo" eqs 2))
+    no(TestModel iscan (_.m at "foo" eqs 2))
+
+//TODO(markcc)    yes(TestModel where (_.n at "foo" eqs 2))
+    no(TestModel where (_.n at "fo" eqs 2))
+    no(TestModel where (_.n at "foot" eqs 2))
+    no(TestModel where (_.n at "bar" eqs 2))
+
+    // $or queries
+    yes(TestModel where (_.a eqs 1) or (_.where(_.b eqs 2), _.where(_.b eqs 2)))
+    no(TestModel where (_.a eqs 1) or (_.where(_.d eqs 4), _.where(_.d eqs 4)))
+    no(TestModel where (_.a eqs 1) or (_.iscan(_.d eqs 4), _.iscan(_.d eqs 4)))
+    yes(TestModel where (_.a eqs 1) or (_.scan(_.d eqs 4), _.scan(_.d eqs 4)))
+    no(TestModel where (_.a eqs 1) or (_.where(_.b eqs 2), _.where(_.d eqs 4)))
+    yes(TestModel where (_.a eqs 1) or (_.where(_.b eqs 2), _.scan(_.d eqs 4)))
+    no(TestModel where (_.a eqs 1) or (_.where(_.c eqs 3), _.where(_.c eqs 3)))
+    yes(TestModel where (_.a eqs 1) or (_.iscan(_.c eqs 3), _.iscan(_.c eqs 3)))
+    no(TestModel where (_.a eqs 1) and (_.b between (2, 2)) or (_.where(_.c eqs 3), _.where(_.c eqs 3)))
+    yes(TestModel where (_.a eqs 1) iscan (_.b between (2, 2)) or (_.iscan(_.c eqs 3), _.iscan(_.c eqs 3)))
+    yes(TestModel where (_.a eqs 1) or (_.where(_.b eqs 2), _.where(_.b eqs 2)) and (_.c eqs 3))
+    no(TestModel where (_.a eqs 1) or (_.where(_.b eqs 2), _.where(_.b > 2)) and (_.c eqs 3))
+    no(TestModel where (_.a eqs 1) or (_.where(_.b eqs 2), _.iscan(_.b > 2)) and (_.c eqs 3))
+    yes(TestModel where (_.a eqs 1) or (_.where(_.b eqs 2), _.iscan(_.b > 2)) iscan (_.c eqs 3))
+  }
+}


### PR DESCRIPTION
This is a recreation of an earlier pull request.

Sorry for the hassle; the earlier pull request was accidentally closed, and since then, I've started using a foursquare-specific github login, which makes it really difficult to work with the old fork, since it's under the wrong ID.

This incorporates all of the changes requested in reviews of the old pull request.
