### PR TITLE
Add pullWhere and pullObjectWhere to ListModifyField's

### DIFF
--- a/src/main/scala/com/foursquare/rogue/MongoHelpers.scala
+++ b/src/main/scala/com/foursquare/rogue/MongoHelpers.scala
@@ -19,7 +19,10 @@ object MongoHelpers {
 
   object MongoBuilder {
     def buildCondition(cond: AndCondition, signature: Boolean = false): DBObject = {
-      val builder = BasicDBObjectBuilder.start
+      buildCondition(cond, BasicDBObjectBuilder.start, signature)
+    }
+
+    def buildCondition(cond: AndCondition, builder: BasicDBObjectBuilder, signature: Boolean): DBObject = {
       val (rawClauses, safeClauses) = cond.clauses.partition(_.isInstanceOf[RawQueryClause])
 
       // Normal clauses

--- a/src/main/scala/com/foursquare/rogue/QueryClause.scala
+++ b/src/main/scala/com/foursquare/rogue/QueryClause.scala
@@ -2,6 +2,7 @@
 
 package com.foursquare.rogue
 
+import com.mongodb.DBObject
 import com.mongodb.BasicDBObjectBuilder
 
 object IndexBehavior extends Enumeration {
@@ -89,5 +90,23 @@ class ModifyBitAndClause[V](fieldName: String, value: V) extends ModifyClause[V]
 class ModifyBitOrClause[V](fieldName: String, value: V) extends ModifyClause[V](ModOps.Bit) {
   override def extend(q: BasicDBObjectBuilder): Unit = {
     q.push(fieldName).add("or", value).pop
+  }
+}
+
+class ModifyPullWithPredicateClause[V](fieldName: String, clauses: QueryClause[_]*)
+    extends ModifyClause[DBObject](ModOps.Pull) {
+  override def extend(q: BasicDBObjectBuilder): Unit = {
+    import com.foursquare.rogue.MongoHelpers.AndCondition
+    MongoHelpers.MongoBuilder.buildCondition(AndCondition(clauses.toList, None), q, false)
+  }
+}
+
+class ModifyPullObjWithPredicateClause[V](fieldName: String, clauses: QueryClause[_]*)
+    extends ModifyClause[DBObject](ModOps.Pull) {
+  override def extend(q: BasicDBObjectBuilder): Unit = {
+    import com.foursquare.rogue.MongoHelpers.AndCondition
+    val nested = q.push(fieldName)
+    MongoHelpers.MongoBuilder.buildCondition(AndCondition(clauses.toList, None), nested, false)
+    nested.pop
   }
 }


### PR DESCRIPTION
Add ability to pull from a list based on a predicate instead of just by
specifying an exact value. For lists of objects, you can also use
pullObjectWhere to have predicates based on subfields.

Example use:

```
Venue.where(_.legacyid eqs 1)
     .modify(_.tags pullWhere(_ startsWith "badprefix"))
```

Or with a list of sub-objects:

```
Venue.where(_.legacyid eqs 1)
     .modify(_.claims pullObjectWhere(_.subfield(_.status) eqs ClaimStatus.approved))
```

You can also specify a list of predicates:

```
Venue.where(_.legacyid eqs 1)
     .modify(_.claims pullObjectWhere(_.subfield(_.status) eqs ClaimStatus.approved,
                                      _.subfield(_.userid) eqs 2097))
```
