### PR TITLE
Don't process RawQueryClause separately

### DIFF
--- a/src/test/scala/com/foursquare/rogue/QueryTest.scala
+++ b/src/test/scala/com/foursquare/rogue/QueryTest.scala
@@ -194,6 +194,9 @@ class QueryTest extends SpecsMatchers {
 
     // raw query clauses
     Venue where (_.mayor eqs 1) raw (_.add("$where", "this.a > 3")) toString() must_== """db.venues.find({ "mayor" : 1 , "$where" : "this.a > 3"})"""
+    val ids = new java.util.ArrayList[Int]() {{ add(1); add(2); add(3) }}
+    Venue where (_.mayor eqs 1) raw (b => {b.push("legid"); b.add("$in", ids)}) toString() must_== """db.venues.find({ "mayor" : 1 , "legid" : { "$in" : [ 1 , 2 , 3]}})"""
+    Venue where (_.mayor eqs 1) raw (b => {b.push("legid"); b.add("$in", ids); b.pop}) and (_.mayor_count eqs 5) toString() must_== """db.venues.find({ "mayor" : 1 , "legid" : { "$in" : [ 1 , 2 , 3]} , "mayor_count" : 5})"""
   }
 
   @Test


### PR DESCRIPTION
Addresses an issue where clauses don't get appended properly if
you use .raw with BasicDBObjectBuilder.push(key). So if you do this:

MyType.where(_._id eqs 1).raw(_.push("$query")).and(_.foo eqs "bar").fetch

Should now produce something like this:

db.mytype.find({ foo : false, $query : { foo : bar } })
