### PR TITLE
fix for subselecting when the top-level field doesn't exist

### DIFF
--- a/src/main/scala/com/foursquare/rogue/Query.scala
+++ b/src/main/scala/com/foursquare/rogue/Query.scala
@@ -810,6 +810,7 @@ case class BaseQuery[M <: MongoRecord[M], R,
                   } yield item.get(fieldName)).toList
                 case dbo: DBObject =>
                   dbo.get(fieldName)
+                case null => null
               }
             }))
           }

--- a/src/test/scala/com/foursquare/rogue/EndToEndTest.scala
+++ b/src/test/scala/com/foursquare/rogue/EndToEndTest.scala
@@ -145,6 +145,13 @@ class EndToEndTest extends SpecsMatchers {
 
     val subuserids: List[Box[List[Long]]] = Venue.where(_._id eqs v.id).select(_.claims.subselect(_.userid)).fetch()
     subuserids must_== List(Full(List(1234, 5678)))
+
+    // selecting a claims.userid when there is no top-level claims list should
+    // have one element in the List for the one Venue, but an Empty for that
+    // Venue since there's no list of claims there.
+    Venue.where(_._id eqs v.id).modify(_.claims unset).and(_.lastClaim unset).updateOne()
+    Venue.where(_._id eqs v.id).select(_.lastClaim.subselect(_.userid)).fetch() must_== List(Empty)
+    Venue.where(_._id eqs v.id).select(_.claims.subselect(_.userid)).fetch() must_== List(Empty)
   }
 
   @Ignore("These tests are broken because DummyField doesn't know how to convert a String to an Enum")


### PR DESCRIPTION
On a select(_.foo.subselect(_.bar)), if foo was unset, rogue would throw
because it wanted foo to either be a DBObject or a BasicDBList, and it
was actually null. The fix is to just return the null and pass that off
to setFromAny. Lift's fields' setFromAny methods will correctly
deserialize that.
