### PR TITLE
move comparison operators up to AbstractQueryField

### DIFF
--- a/src/main/scala/com/foursquare/rogue/QueryField.scala
+++ b/src/main/scala/com/foursquare/rogue/QueryField.scala
@@ -65,6 +65,19 @@ abstract class AbstractQueryField[V, DB, M <: BsonRecord[M]](val field: Field[V,
   def neqs(v: V) = new NeQueryClause(field.name, valueToDB(v))
   def in[L <% Traversable[V]](vs: L) = QueryHelpers.inListClause(field.name, valuesToDB(vs))
   def nin[L <% Traversable[V]](vs: L) = new NinQueryClause(field.name, QueryHelpers.validatedList(valuesToDB(vs)))
+
+  def lt(v: V) = new LtQueryClause(field.name, valueToDB(v))
+  def gt(v: V) = new GtQueryClause(field.name, valueToDB(v))
+  def lte(v: V) = new LtEqQueryClause(field.name, valueToDB(v))
+  def gte(v: V) = new GtEqQueryClause(field.name, valueToDB(v))
+
+  def <(v: V) = lt(v)
+  def <=(v: V) = lte(v)
+  def >(v: V) = gt(v)
+  def >=(v: V) = gte(v)
+
+  def between(v1: V, v2: V) =
+    new BetweenQueryClause(field.name, valueToDB(v1), valueToDB(v2))
 }
 
 class QueryField[V, M <: BsonRecord[M]](field: Field[V, M])
@@ -114,25 +127,6 @@ class GeoQueryField[M <: BsonRecord[M]](field: Field[LatLong, M])
 
 abstract class AbstractNumericQueryField[V, DB, M <: BsonRecord[M]](field: Field[V, M])
     extends AbstractQueryField[V, DB, M](field) {
-  def lt(v: V) = new LtQueryClause(field.name, valueToDB(v))
-
-  def gt(v: V) = new GtQueryClause(field.name, valueToDB(v))
-
-  def lte(v: V) = new LtEqQueryClause(field.name, valueToDB(v))
-
-  def gte(v: V) = new GtEqQueryClause(field.name, valueToDB(v))
-
-  def <(v: V) = lt(v)
-
-  def <=(v: V) = lte(v)
-
-  def >(v: V) = gt(v)
-
-  def >=(v: V) = gte(v)
-
-  def between(v1: V, v2: V) =
-    new BetweenQueryClause(field.name, valueToDB(v1), valueToDB(v2))
-
   def mod(by: Int, eq: Int) =
     new ModQueryClause(field.name, QueryHelpers.list(List(by, eq)))
 }

--- a/src/test/scala/com/foursquare/rogue/QueryTest.scala
+++ b/src/test/scala/com/foursquare/rogue/QueryTest.scala
@@ -49,6 +49,12 @@ class QueryTest extends SpecsMatchers {
     Venue where (_.mayor_count between (3, 5)) toString() must_== """db.venues.find({ "mayor_count" : { "$gte" : 3 , "$lte" : 5}})"""
     VenueClaim where (_.status neqs ClaimStatus.approved) toString() must_== """db.venueclaims.find({ "status" : { "$ne" : "Approved"}})"""
 
+    // comparison even when type information is unavailable
+    def doLessThan[M <: MongoRecord[M], T](meta: M with MongoMetaRecord[M], f: M => Field[T, M], otherVal: T) =
+      meta.where(r => f(r) < otherVal)
+    doLessThan(Venue, (v: Venue) => v.mayor_count, 5L) toString() must_== """db.venues.find({ "mayor_count" : { "$lt" : 5}})"""
+
+
     // in,nin
     Venue where (_.legacyid in List(123L, 456L)) toString() must_== """db.venues.find({ "legid" : { "$in" : [ 123 , 456]}})"""
     Venue where (_.venuename nin List("Starbucks", "Whole Foods")) toString() must_== """db.venues.find({ "venuename" : { "$nin" : [ "Starbucks" , "Whole Foods"]}})"""


### PR DESCRIPTION
The documentation on comparison operators at
http://www.mongodb.org/display/DOCS/Advanced+Queries#AdvancedQueries-%3C%2C%3C%3D%2C%3E%2C%3E%3D
doesn't list any restrictions on what types can be compared. For any
type that can be indexed, mongo must be able to do comparisons on that
type, and so these comparators should work.
