### PR TITLE
Change joda-time version to publicly-resolvable 2.1 version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies <++= (scalaVersion) { scalaVersion =>
     "net.liftweb"             %% "lift-mongodb"        % liftVersion  % "compile" intransitive(),
     "net.liftweb"             %% "lift-webkit"         % liftVersion  % "compile" intransitive(),
     "net.liftweb"             %% "lift-json"           % liftVersion  % "compile",
-    "joda-time"                % "joda-time"           % "2.0_2012b"  % "compile",
+    "joda-time"                % "joda-time"           % "2.1"        % "compile",
     "org.joda"                 % "joda-convert"        % "1.2"        % "compile",
     "org.mongodb"              % "mongo-java-driver"   % "2.7.3"      % "compile",
     "junit"                    % "junit"               % "4.5"        % "test",


### PR DESCRIPTION
Fix for build failing with unresolved dependencies for joda-time:

[warn]     ::::::::::::::::::::::::::::::::::::::::::::::
[warn]     ::          UNRESOLVED DEPENDENCIES         ::
[warn]     ::::::::::::::::::::::::::::::::::::::::::::::
[warn]     :: joda-time#joda-time;2.0_2012b: not found
[warn]     ::::::::::::::::::::::::::::::::::::::::::::::
