### PR TITLE
Support any collection type with iterateBatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # 2.0.0-beta5
 
 - Internal: Use standard Either convention of failure on the Left.
+- support any collection type (not just List) with iterateBatch
 
 # 2.0.0-beta4
 

--- a/rogue-core/src/main/scala/com/foursquare/rogue/QueryExecutor.scala
+++ b/rogue-core/src/main/scala/com/foursquare/rogue/QueryExecutor.scala
@@ -4,6 +4,7 @@ package com.foursquare.rogue
 
 import com.foursquare.rogue.MongoHelpers.{MongoModify, MongoSelect}
 import com.mongodb.{DBObject, ReadPreference, WriteConcern}
+import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable.ListBuffer
 
 trait RogueSerializer[R] {
@@ -235,12 +236,14 @@ trait QueryExecutor[MB] {
     }
   }
 
-  def iterateBatch[S, M <: MB, R](
+  def iterateBatch[S, M <: MB, R, CollType <: Traversable[R]](
       query: AbstractQuery[M, R, _, _, _, _, _],
       batchSize: Int,
       state: S
   )(
-      handler: (S, Rogue.Iter.Event[List[R]]) => Rogue.Iter.Command[S]
+      handler: (S, Rogue.Iter.Event[CollType]) => Rogue.Iter.Command[S]
+  )(
+      implicit cbf: CanBuildFrom[Traversable[_], R, CollType]
   ): S = {
     if (optimizer.isEmptyQuery(query)) {
       handler(state, Rogue.Iter.EOF).state

--- a/rogue-lift/src/main/scala/com/foursquare/rogue/ExecutableQuery.scala
+++ b/rogue-lift/src/main/scala/com/foursquare/rogue/ExecutableQuery.scala
@@ -126,7 +126,7 @@ case class ExecutableQuery[
   def iterate[S](state: S)(handler: (S, Rogue.Iter.Event[R]) => Rogue.Iter.Command[S]): S =
     db.iterate(query, state)(handler)
 
-  def iterateBatch[S](batchSize: Int, state: S)(handler: (S, Rogue.Iter.Event[List[R]]) => Rogue.Iter.Command[S]): S =
+  def iterateBatch[S, CollType <: Traversable[R]](batchSize: Int, state: S)(handler: (S, Rogue.Iter.Event[Traversable[R]]) => Rogue.Iter.Command[S]): S =
     db.iterateBatch(query, batchSize, state)(handler)
 }
 

--- a/rogue-lift/src/test/scala/com/foursquare/rogue/EndToEndTest.scala
+++ b/rogue-lift/src/test/scala/com/foursquare/rogue/EndToEndTest.scala
@@ -253,7 +253,7 @@ class EndToEndTest extends SpecsMatchers {
     items1.map(_.legacyid.value) must_== List(6, 4, 2)
 
     val items2 = Venue.where(_._id in ids)
-        .iterateBatch[List[Venue]](2, Nil){ case (accum, event) => {
+        .iterateBatch(2, List[Venue]()){ case (accum, event) => {
       if (accum.length >= 3) {
         Return(accum)
       } else {


### PR DESCRIPTION
List is an implementation type. We should support any particular collection
type that the caller would like to use with its iteratee.
