### PR TITLE
include instanceName param in log callbacks

### DIFF
--- a/rogue-core/src/main/scala/com/foursquare/rogue/MongoJavaDriverAdapter.scala
+++ b/rogue-core/src/main/scala/com/foursquare/rogue/MongoJavaDriverAdapter.scala
@@ -23,15 +23,16 @@ class MongoJavaDriverAdapter[MB](dbCollectionFactory: DBCollectionFactory[MB]) {
     // Use nanoTime instead of currentTimeMillis to time the query since
     // currentTimeMillis only has 10ms granularity on many systems.
     val start = System.nanoTime
+    val instanceName: String = dbCollectionFactory.getInstanceName(query)
     try {
-      logger.onExecuteQuery(query, description, f)
+      logger.onExecuteQuery(query, instanceName, description, f)
     } catch {
       case e: Exception =>
         throw new RogueException("Mongo query on %s [%s] failed after %d ms".
-                                 format(dbCollectionFactory.getInstanceName(query),
-          description, (System.nanoTime - start) / (1000 * 1000)), e)
+                                 format(instanceName, description,
+          (System.nanoTime - start) / (1000 * 1000)), e)
     } finally {
-      logger.log(query, description, (System.nanoTime - start) / (1000 * 1000))
+      logger.log(query, instanceName, description, (System.nanoTime - start) / (1000 * 1000))
     }
   }
 

--- a/rogue-core/src/main/scala/com/foursquare/rogue/QueryHelpers.scala
+++ b/rogue-core/src/main/scala/com/foursquare/rogue/QueryHelpers.scala
@@ -30,16 +30,16 @@ object QueryHelpers {
     (net.liftweb.json.DefaultFormats + new ObjectIdSerializer + new DBObjectSerializer)
 
   trait QueryLogger {
-    def log(query: Query[_, _, _], msg: => String, timeMillis: Long): Unit
-    def onExecuteQuery[T](query: Query[_, _, _], msg: => String, func: => T): T
+    def log(query: Query[_, _, _], instanceName: String, msg: => String, timeMillis: Long): Unit
+    def onExecuteQuery[T](query: Query[_, _, _], instanceName: String, msg: => String, func: => T): T
     def logIndexMismatch(query: Query[_, _, _], msg: => String)
     def logIndexHit(query: Query[_, _, _], index: MongoIndex[_])
     def warn(query: Query[_, _, _], msg: => String): Unit
   }
 
   class DefaultQueryLogger extends QueryLogger {
-    override def log(query: Query[_, _, _], msg: => String, timeMillis: Long) {}
-    override def onExecuteQuery[T](query: Query[_, _, _], msg: => String, func: => T): T = func
+    override def log(query: Query[_, _, _], instanceName: String, msg: => String, timeMillis: Long) {}
+    override def onExecuteQuery[T](query: Query[_, _, _], instanceName: String, msg: => String, func: => T): T = func
     override def logIndexMismatch(query: Query[_, _, _], msg: => String) {}
     override def logIndexHit(query: Query[_, _, _], index: MongoIndex[_]) {}
     override def warn(query: Query[_, _, _], msg: => String) {}


### PR DESCRIPTION
so we can distinguish between queries run on
different clusters.
