### PR TITLE
ClassCastException thrown if you have iteratee with projection to a field that have different types stored in mongo and locally.

### DIFF
--- a/rogue-lift/src/main/scala/com/foursquare/rogue/LiftQueryExecutor.scala
+++ b/rogue-lift/src/main/scala/com/foursquare/rogue/LiftQueryExecutor.scala
@@ -4,10 +4,13 @@ package com.foursquare.rogue
 
 import com.foursquare.rogue.MongoHelpers.MongoSelect
 import net.liftweb.common.{Box, Full}
-import net.liftweb.mongodb.record.{MongoRecord, MongoMetaRecord}
+import net.liftweb.mongodb.record.{BsonRecord, BsonMetaRecord, MongoRecord, MongoMetaRecord}
 import org.bson.types.BasicBSONList
 import net.liftweb.mongodb.MongoDB
 import com.mongodb.{DBCollection, DBObject}
+import sun.reflect.generics.reflectiveObjects.NotImplementedException
+import net.liftweb.mongodb.record.field.BsonRecordField
+import net.liftweb.record.Record
 
 object LiftDBCollectionFactory extends DBCollectionFactory[MongoRecord[_] with MongoMetaRecord[_]] {
   override def getDBCollection[M <: MongoRecord[_] with MongoMetaRecord[_]](query: Query[M, _, _]): DBCollection = {
@@ -67,25 +70,59 @@ class LiftQueryExecutor(override val adapter: MongoJavaDriverAdapter[MongoRecord
 object LiftQueryExecutor extends LiftQueryExecutor(LiftAdapter)
 
 object LiftQueryExecutorHelpers {
-  def setInstanceFieldFromDbo(instance: MongoRecord[_], dbo: DBObject, fieldName: String): Option[_] = {
-    val fieldBox: Box[net.liftweb.record.Field[_, _]] = instance.fieldByName(fieldName)
-    fieldBox match {
-      case Full(field) => field.setFromAny(dbo.get(fieldName)).toOption
-      case _ => {
-        val splitName = fieldName.split('.').toList
-        Box.!!(splitName.foldLeft(dbo: Object)((obj: Object, fieldName: String) => {
-          obj match {
-            case dbl: BasicBSONList =>
-              (for {
-                index <- 0 to dbl.size - 1
-                val item: DBObject = dbl.get(index).asInstanceOf[DBObject]
-              } yield item.get(fieldName)).toList
-            case dbo: DBObject =>
-              dbo.get(fieldName)
-            case null => null
-          }
-        })).toOption
+  import net.liftweb.record.{Field => LField}
+
+  def setInstanceFieldFromDboList(instance: BsonRecord[_], dbo: DBObject, fieldNames: List[String]): Option[_] = {
+    fieldNames match {
+      case last :: Nil =>
+        val fld: Box[LField[_, _]] = instance.fieldByName(last)
+        fld.flatMap(setLastFieldFromDbo(_, dbo, last))
+      case name :: rest =>
+        val fld: Box[LField[_, _]] = instance.fieldByName(name)
+        dbo.get(name) match {
+          case obj: DBObject => fld.flatMap(setFieldFromDbo(_, obj, rest))
+          case list: BasicBSONList => fallbackValueFromDbObject(dbo, fieldNames)
+          case null => None
       }
+      case Nil => throw new UnsupportedOperationException("was called with empty list, shouldn't possibly happen")
     }
+  }
+
+  def setFieldFromDbo(field: LField[_, _], dbo: DBObject, fieldNames: List[String]): Option[_] = {
+    if (field.isInstanceOf[BsonRecordField[_, _]]) {
+      val brf = field.asInstanceOf[BsonRecordField[_, _]]
+      val inner = brf.value.asInstanceOf[BsonRecord[_]]
+      setInstanceFieldFromDboList(inner, dbo, fieldNames)
+    } else {
+      fallbackValueFromDbObject(dbo, fieldNames)
+    }
+  }
+
+  def setLastFieldFromDbo(field: LField[_, _], dbo: DBObject, fieldName: String): Option[_] = {
+    field.setFromAny(dbo.get(fieldName)).toOption
+  }
+
+  def setInstanceFieldFromDbo(instance: MongoRecord[_], dbo: DBObject, fieldName: String): Option[_] = {
+    fieldName.contains(".") match {
+      case true =>
+        val names = fieldName.split("\\.").toList
+        setInstanceFieldFromDboList(instance, dbo, names)
+      case false =>
+        val fld: Box[LField[_, _]] = instance.fieldByName(fieldName)
+        fld.flatMap (setLastFieldFromDbo(_, dbo, fieldName))
+    }
+  }
+
+  def fallbackValueFromDbObject(dbo: DBObject, fieldNames: List[String]): Option[_] = {
+    import scala.collection.JavaConversions._
+    Box.!!(fieldNames.foldLeft(dbo: Object)((obj: Object, fieldName: String) => {
+      obj match {
+        case dbl: BasicBSONList =>
+          dbl.map(_.asInstanceOf[DBObject]).map(_.get(fieldName)).toList
+        case dbo: DBObject =>
+          dbo.get(fieldName)
+        case null => null
+      }
+    })).toOption
   }
 }

--- a/rogue-lift/src/test/scala/com/foursquare/rogue/IterateeTestForBsonRecordSubfields.scala
+++ b/rogue-lift/src/test/scala/com/foursquare/rogue/IterateeTestForBsonRecordSubfields.scala
@@ -1,0 +1,65 @@
+package com.foursquare.rogue
+
+import org.specs2.matcher.JUnitMustMatchers
+import org.junit.{Test, After, Before}
+import net.liftweb.mongodb.record.{BsonMetaRecord, BsonRecord, MongoRecord, MongoMetaRecord}
+import net.liftweb.mongodb.record.field.{BsonRecordField, ObjectIdPk}
+import net.liftweb.record.field.DateTimeField
+import java.util.Calendar
+
+/**
+ * @author eiennohito
+ * @since 28.02.13 
+ */
+
+class CalendarFld private() extends MongoRecord[CalendarFld] with ObjectIdPk[CalendarFld] {
+  def meta = CalendarFld
+
+  object inner extends BsonRecordField(this, CalendarInner)
+}
+
+object CalendarFld extends CalendarFld with MongoMetaRecord[CalendarFld] {
+  override def mongoIdentifier = RogueTestMongo
+}
+
+class CalendarInner private() extends BsonRecord[CalendarInner] {
+  def meta = CalendarInner
+
+  object date extends DateTimeField(this) //actually calendar field, not joda DateTime
+}
+
+object CalendarInner extends CalendarInner with BsonMetaRecord[CalendarInner]
+
+class IterateeTestForBsonRecordSubfields extends JUnitMustMatchers {
+  import LiftRogue._
+
+  @Before
+  def initialize() {
+    RogueTestMongo.connectToMongo
+
+    val inner = CalendarInner.createRecord.date(Calendar.getInstance())
+    CalendarFld.createRecord.inner(inner).save
+  }
+
+  @After
+  def teardown() {
+    CalendarFld bulkDelete_!!!()
+
+    RogueTestMongo.disconnectFromMongo
+  }
+
+  @Test
+  def testIteratee() {
+    val q = CalendarFld select(_.inner.subfield(_.date))
+    val cnt = q.count()
+    val list = q.iterate(List[Calendar]()) {
+      case (list, Iter.Item(cal)) =>
+        val c: Calendar = cal.get //class cast exception was here
+        c.set(Calendar.HOUR_OF_DAY, 0)
+        Iter.Continue(c :: list)
+      case (list, Iter.Error(e)) => e.printStackTrace(); Iter.Continue(list)
+      case (list, _) => Iter.Return(list)
+    }
+    list.length must_== (cnt)
+  }
+}


### PR DESCRIPTION
If you have record with BsonRecord as subrecord and store there fields that have different representation than in mongo (eg java.util.Calendar or joda DateTime in field and get java.util.Date from mongo driver) than you will have class cast exception when trying to use 
the value got from Iter.Item.

Small code example: (same in pull request test case) https://gist.github.com/eiennohito/5053813
