### PR TITLE
Add BSONType type class for types serializable to BSON

### DIFF
--- a/project/RogueBuild.scala
+++ b/project/RogueBuild.scala
@@ -14,7 +14,7 @@ object RogueBuild extends Build {
   lazy val lift = Project("rogue-lift", file("rogue-lift/")) dependsOn(core % "compile;test->test;runtime->runtime")
 
   lazy val defaultSettings: Seq[Setting[_]] = Seq(
-    version := "2.0.0-RC2-SNAPSHOT",
+    version := "2.0.0-RC2",
     organization := "com.foursquare",
     crossScalaVersions := Seq("2.9.1", "2.9.2", "2.10.0", "2.9.0-1", "2.9.0"),
     publishMavenStyle := true,

--- a/rogue-core/src/main/scala/com/foursquare/rogue/BSONType.scala
+++ b/rogue-core/src/main/scala/com/foursquare/rogue/BSONType.scala
@@ -1,0 +1,78 @@
+// Copyright 2013 Foursquare Labs Inc. All Rights Reserved.
+
+package com.foursquare.rogue
+
+import com.mongodb.DBObject
+import java.util.Date
+import org.bson.types.ObjectId
+
+trait BSONType[T] {
+  def asBSONObject(v: T): AnyRef
+}
+
+object BSONType {
+  def apply[T: BSONType]: BSONType[T] = implicitly[BSONType[T]]
+
+  implicit object BooleanIsBSONType extends BSONType[Boolean] {
+    override def asBSONObject(v: Boolean): AnyRef = v: java.lang.Boolean
+  }
+  implicit object CharIsBSONType extends BSONType[Char] {
+    override def asBSONObject(v: Char): AnyRef = v: java.lang.Character
+  }
+  implicit object ShortIsBSONType extends BSONType[Short] {
+    override def asBSONObject(v: Short): AnyRef = v: java.lang.Short
+  }
+  implicit object IntIsBSONType extends BSONType[Int] {
+    override def asBSONObject(v: Int): AnyRef = v: java.lang.Integer
+  }
+  implicit object LongIsBSONType extends BSONType[Long] {
+    override def asBSONObject(v: Long): AnyRef = v: java.lang.Long
+  }
+  implicit object FloatIsBSONType extends BSONType[Float] {
+    override def asBSONObject(v: Float): AnyRef = v: java.lang.Float
+  }
+  implicit object DoubleIsBSONType extends BSONType[Double] {
+    override def asBSONObject(v: Double): AnyRef = v: java.lang.Double
+  }
+  implicit object DateIsBSONType extends BSONType[Date] {
+    override def asBSONObject(v: Date): AnyRef = v
+  }
+  implicit object DBObjectIsBSONType extends BSONType[DBObject] {
+    override def asBSONObject(v: DBObject): AnyRef = v
+  }
+  implicit object StringIsBSONType extends BSONType[String] {
+    override def asBSONObject(v: String): AnyRef = v
+  }
+  implicit object ObjectIdISBSONType extends BSONType[ObjectId] {
+    override def asBSONObject(v: ObjectId): AnyRef = v
+  }
+
+  implicit def ObjectIdSubtypesAreBSONTypes[T <: ObjectId]: BSONType[T] =
+    ObjectIdISBSONType.asInstanceOf[BSONType[T]]
+
+  class ListsOfBSONTypesAreBSONTypes[T: BSONType] extends BSONType[List[T]] {
+    override def asBSONObject(v: List[T]): AnyRef = {
+      val bsonType = BSONType[T]
+      val ret = new java.util.ArrayList[AnyRef](v.size)
+      for (x <- v) {
+        ret.add(bsonType.asBSONObject(x))
+      }
+      ret
+    }
+  }
+
+  implicit def ListsOfBSONTypesAreBSONTypes[T: BSONType]: BSONType[List[T]] = new ListsOfBSONTypesAreBSONTypes[T]
+
+  class SeqsOfBSONTypesAreBSONTypes[T: BSONType] extends BSONType[Seq[T]] {
+    override def asBSONObject(v: Seq[T]): AnyRef = {
+      val bsonType = BSONType[T]
+      val ret = new java.util.ArrayList[AnyRef](v.size)
+      for (x <- v) {
+        ret.add(bsonType.asBSONObject(x))
+      }
+      ret
+    }
+  }
+
+  implicit def SeqsOfBSONTypesAreBSONTypes[T: BSONType]: BSONType[Seq[T]] = new SeqsOfBSONTypesAreBSONTypes[T]
+}

--- a/rogue-core/src/main/scala/com/foursquare/rogue/Rogue.scala
+++ b/rogue-core/src/main/scala/com/foursquare/rogue/Rogue.scala
@@ -60,8 +60,8 @@ trait Rogue {
   implicit def renumerationListFieldToEnumerationListQueryField[M, F <: Enumeration#Value](f: RField[List[F], M]): EnumerationListQueryField[F, M] = new EnumerationListQueryField[F, M](f)
   implicit def rlatLongFieldToGeoQueryField[M](f: RField[LatLong, M]): GeoQueryField[M] = new GeoQueryField(f)
   implicit def rStringsListFieldToStringsListQueryField[M](f: RField[List[String], M]): StringsListQueryField[M] = new StringsListQueryField[M](f)
-  implicit def rlistFieldToListQueryField[M, F](f: RField[List[F], M]): ListQueryField[F, M] = new ListQueryField[F, M](f)
-  implicit def rseqFieldToSeqQueryField[M, F](f: RField[Seq[F], M]): SeqQueryField[F, M] = new SeqQueryField[F, M](f)
+  implicit def rlistFieldToListQueryField[M, F: BSONType](f: RField[List[F], M]): ListQueryField[F, M] = new ListQueryField[F, M](f)
+  implicit def rseqFieldToSeqQueryField[M, F: BSONType](f: RField[Seq[F], M]): SeqQueryField[F, M] = new SeqQueryField[F, M](f)
   implicit def rmapFieldToMapQueryField[M, F](f: RField[Map[String, F], M]): MapQueryField[F, M] = new MapQueryField[F, M](f)
 
   /** ModifyField implicits
@@ -69,6 +69,7 @@ trait Rogue {
     * These are dangerous in the general case, unless the field type can be safely serialized
     * or the field class handles necessary serialization. We specialize some safe cases.
     **/
+  implicit def rfieldToSafeModifyField[M, F](f: RField[F, M]): SafeModifyField[F, M] = new SafeModifyField(f)
   implicit def booleanRFieldToModifyField[M](f: RField[Boolean, M]): ModifyField[Boolean, M] = new ModifyField(f)
   implicit def charRFieldToModifyField[M](f: RField[Char, M]): ModifyField[Char, M] = new ModifyField(f)
 
@@ -95,10 +96,10 @@ trait Rogue {
   implicit def rlatLongFieldToGeoQueryModifyField[M](f: RField[LatLong, M]): GeoModifyField[M] =
     new GeoModifyField(f)
 
-  implicit def rlistFieldToListModifyField[M, F](f: RField[List[F], M]): ListModifyField[F, M] =
+  implicit def rlistFieldToListModifyField[M, F: BSONType](f: RField[List[F], M]): ListModifyField[F, M] =
     new ListModifyField[F, M](f)
 
-  implicit def rSeqFieldToSeqModifyField[M, F](f: RField[Seq[F], M]): SeqModifyField[F, M] =
+  implicit def rSeqFieldToSeqModifyField[M, F: BSONType](f: RField[Seq[F], M]): SeqModifyField[F, M] =
     new SeqModifyField[F, M](f)
 
   implicit def rmapFieldToMapModifyField[M, F](f: RField[Map[String, F], M]): MapModifyField[F, M] =

--- a/rogue-lift/src/main/scala/com/foursquare/rogue/LiftRogue.scala
+++ b/rogue-lift/src/main/scala/com/foursquare/rogue/LiftRogue.scala
@@ -83,7 +83,7 @@ trait LiftRogue extends Rogue {
     liftQuery
   }
 
-  implicit def fieldToQueryField[M <: BsonRecord[M], F](f: Field[F, M]): QueryField[F, M] = new QueryField(f)
+  implicit def fieldToQueryField[M <: BsonRecord[M], F: BSONType](f: Field[F, M]): QueryField[F, M] = new QueryField(f)
 
   implicit def bsonRecordFieldToBsonRecordQueryField[
       M <: BsonRecord[M],
@@ -165,7 +165,7 @@ trait LiftRogue extends Rogue {
   implicit def latLongFieldToGeoQueryField[M <: BsonRecord[M]](f: Field[LatLong, M]): GeoQueryField[M] =
     new GeoQueryField(f)
 
-  implicit def listFieldToListQueryField[M <: BsonRecord[M], F](f: Field[List[F], M]): ListQueryField[F, M] =
+  implicit def listFieldToListQueryField[M <: BsonRecord[M], F: BSONType](f: Field[List[F], M]): ListQueryField[F, M] =
     new ListQueryField[F, M](f)
 
   implicit def stringsListFieldToStringsListQueryField[M <: BsonRecord[M]](f: Field[List[String], M]): StringsListQueryField[M] =
@@ -184,7 +184,8 @@ trait LiftRogue extends Rogue {
     new StringQueryField(f)
 
   // ModifyField implicits
-  implicit def fieldToModifyField[M <: BsonRecord[M], F](f: Field[F, M]): ModifyField[F, M] = new ModifyField(f)
+  implicit def fieldToModifyField[M <: BsonRecord[M], F: BSONType](f: Field[F, M]): ModifyField[F, M] = new ModifyField(f)
+  implicit def fieldToSafeModifyField[M <: BsonRecord[M], F](f: Field[F, M]): SafeModifyField[F, M] = new SafeModifyField(f)
 
   implicit def bsonRecordFieldToBsonRecordModifyField[M <: BsonRecord[M], B <: BsonRecord[B]]
       (f: BsonRecordField[M, B]): BsonRecordModifyField[M, B] =
@@ -228,7 +229,7 @@ trait LiftRogue extends Rogue {
   implicit def latLongFieldToGeoQueryModifyField[M <: BsonRecord[M]](f: Field[LatLong, M]): GeoModifyField[M] =
     new GeoModifyField(f)
 
-  implicit def listFieldToListModifyField[M <: BsonRecord[M], F](f: Field[List[F], M]): ListModifyField[F, M] =
+  implicit def listFieldToListModifyField[M <: BsonRecord[M], F: BSONType](f: Field[List[F], M]): ListModifyField[F, M] =
     new ListModifyField[F, M](f)
 
   implicit def longFieldToNumericModifyField[M <: BsonRecord[M]](f: Field[Long, M]): NumericModifyField[Long, M] =
@@ -261,6 +262,14 @@ trait LiftRogue extends Rogue {
     override def name = f.name
     override def owner = f.owner
   }
+
+  class BsonRecordIsBSONType[T <: BsonRecord[T]] extends BSONType[T] {
+    override def asBSONObject(v: T): AnyRef = v.asDBObject
+  }
+
+  object _BsonRecordIsBSONType extends BsonRecordIsBSONType[Nothing]
+
+  implicit def BsonRecordIsBSONType[T <: BsonRecord[T]]: BSONType[T] = _BsonRecordIsBSONType.asInstanceOf[BSONType[T]]
 }
 
 object LiftRogue extends LiftRogue

--- a/rogue-lift/src/test/scala/com/foursquare/rogue/QueryTest.scala
+++ b/rogue-lift/src/test/scala/com/foursquare/rogue/QueryTest.scala
@@ -55,7 +55,7 @@ class QueryTest extends JUnitMustMatchers {
     VenueClaim.where(_.reason eqs RejectReason.wrongCode).toString() must_== """db.venueclaims.find({ "reason" : 2})"""
 
     // comparison even when type information is unavailable
-    def doLessThan[M <: MongoRecord[M], T](meta: M with MongoMetaRecord[M], f: M => Field[T, M], otherVal: T) =
+    def doLessThan[M <: MongoRecord[M], T: BSONType](meta: M with MongoMetaRecord[M], f: M => Field[T, M], otherVal: T) =
       meta.where(r => f(r) < otherVal)
     doLessThan(Venue, (v: Venue) => v.mayor_count, 5L).toString() must_== """db.venues.find({ "mayor_count" : { "$lt" : 5}})"""
 


### PR DESCRIPTION
Get rid of serialization exceptions once and for all.

Create a type class that allows certain types to be serialized into BSON.
