### PR TITLE
Update README.md to reflect v2.0.0 release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,18 +33,18 @@ are in place to prevent you from accidentally doing things you don't want to do 
 
 ## Installation
 
-Because Rogue is designed to work with several versions of lift-mongodb-record (2.2, 2.3, 2.4),
+Because Rogue is designed to work with several versions of lift-mongodb-record (2.2, 2.3, 2.4, 2.5),
 you'll want to declare your dependency on Rogue as `intransitive` and declare an explicit dependency
 on the version of Lift you want to target. In sbt, that would look like the following: 
 
-    val rogueField      = "com.foursquare" %% "rogue-field"         % "2.0.0-beta14" intransitive()
-    val rogueCore       = "com.foursquare" %% "rogue-core"          % "2.0.0-beta14" intransitive()
-    val rogueLift       = "com.foursquare" %% "rogue-lift"          % "2.0.0-beta14" intransitive()
-    val liftMongoRecord = "net.liftweb"    %% "lift-mongodb-record" % "2.4-M5"
+    val rogueField      = "com.foursquare" %% "rogue-field"         % "2.0.0" intransitive()
+    val rogueCore       = "com.foursquare" %% "rogue-core"          % "2.0.0" intransitive()
+    val rogueLift       = "com.foursquare" %% "rogue-lift"          % "2.0.0" intransitive()
+    val liftMongoRecord = "net.liftweb"    %% "lift-mongodb-record" % "2.5"
 
-You can substitute "2.4-M2" for whatever version of Lift you are using. Rogue has been used in
-production against Lift 2.2 and 2.4-M2. If you encounter problems using Rogue with other versions
-of Lift, please let us know.
+You can substitute "2.5" for whatever version of Lift you are using. Rogue has been used in
+production against Lift versions including 2.2 and 2.4-M2. If you encounter problems using 
+Rogue with other versions of Lift, please let us know.
 
 Join the [rogue-users google group](http://groups.google.com/group/rogue-users) for help, bug reports,
 feature requests, and general discussion on Rogue.
@@ -88,7 +88,7 @@ for "findAndModify" query objects
 
 ## Releases
 
-The latest release is 2.0.0-beta14. See the [changelog](https://github.com/foursquare/rogue/blob/master/CHANGELOG.md) for more details.
+The latest release is 2.0.0. See the [changelog](https://github.com/foursquare/rogue/blob/master/CHANGELOG.md) for more details.
 
 New since 1.1.0:
 
@@ -159,7 +159,7 @@ Other recent notable changes:
 
 ## Dependencies
 
-lift-mongodb-record (2.2, 2.3, 2.4), mongodb, joda-time, junit. These dependencies are managed by the build system.
+lift-mongodb-record (2.2, 2.3, 2.4, 2.5), mongodb, joda-time, junit. These dependencies are managed by the build system.
 
 ## Maintainers
 


### PR DESCRIPTION
- Rogue version is v2.0.0
- Latest lift-mongodb-record version supported is 2.5 definitely
