### PR TITLE
Add sbt-idea plugin (eases working in IntelliJ)

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 resolvers += Resolver.url("scalasbt", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))  (Resolver.ivyStylePatterns)
 
 addSbtPlugin("com.jsuereth" % "xsbt-gpg-plugin" % "0.6")
+
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.4.0")


### PR DESCRIPTION
Simply adds the plugins.sbt line to allow one to type `sbt gen-idea` to generate/update IntelliJ project.
