### PR TITLE
Replaced usage of MongoId with ObjectIdPk

### DIFF
--- a/rogue-lift/src/main/scala/com/foursquare/rogue/HasMongoForeignObjectId.scala
+++ b/rogue-lift/src/main/scala/com/foursquare/rogue/HasMongoForeignObjectId.scala
@@ -2,6 +2,7 @@
 
 package com.foursquare.rogue
 
-import net.liftweb.mongodb.record.{MongoId, MongoRecord}
+import net.liftweb.mongodb.record.MongoRecord
+import net.liftweb.mongodb.record.field.ObjectIdPk
 
-trait HasMongoForeignObjectId[RefType <: MongoRecord[RefType] with MongoId[RefType]]
+trait HasMongoForeignObjectId[RefType <: MongoRecord[RefType] with ObjectIdPk[RefType]]

--- a/rogue-lift/src/main/scala/com/foursquare/rogue/LiftRogue.scala
+++ b/rogue-lift/src/main/scala/com/foursquare/rogue/LiftRogue.scala
@@ -10,10 +10,11 @@ import com.foursquare.index.IndexBuilder
 import com.foursquare.rogue.MongoHelpers.{AndCondition, MongoModify}
 import java.util.Date
 import net.liftweb.json.JsonAST.{JArray, JInt}
-import net.liftweb.mongodb.record.{BsonRecord, MongoId, MongoRecord, MongoMetaRecord}
+import net.liftweb.mongodb.record.{BsonRecord, MongoRecord, MongoMetaRecord}
 import net.liftweb.record.{Field, MandatoryTypedField, OptionalTypedField, Record}
 import net.liftweb.mongodb.record.field.{
-    BsonRecordField, BsonRecordListField, MongoCaseClassField, MongoCaseClassListField}
+    BsonRecordField, BsonRecordListField, MongoCaseClassField, MongoCaseClassListField,
+    ObjectIdPk}
 import org.bson.types.ObjectId
 import net.liftweb.record.field.EnumField
 
@@ -155,9 +156,9 @@ trait LiftRogue extends Rogue {
     new EnumerationListQueryField[F, M](f)
 
   implicit def foreignObjectIdFieldToForeignObjectIdQueryField[M <: BsonRecord[M],
-                                                               T <: MongoRecord[T] with MongoId[T]]
+                                                               T <: MongoRecord[T] with ObjectIdPk[T]]
       (f: Field[ObjectId, M] with HasMongoForeignObjectId[T]): ForeignObjectIdQueryField[ObjectId, M, T] =
-    new ForeignObjectIdQueryField[ObjectId, M, T](f, _.id)
+    new ForeignObjectIdQueryField[ObjectId, M, T](f, _.id.value)
 
   implicit def intFieldtoNumericQueryField[M <: BsonRecord[M], F](f: Field[Int, M]): NumericQueryField[Int, M] =
     new NumericQueryField(f)

--- a/rogue-lift/src/test/scala/com/foursquare/rogue/EndToEndTest.scala
+++ b/rogue-lift/src/test/scala/com/foursquare/rogue/EndToEndTest.scala
@@ -67,49 +67,49 @@ class EndToEndTest extends JUnitMustMatchers {
   @Test
   def eqsTests: Unit = {
     val v = baseTestVenue().save
-    val vc = baseTestVenueClaim(v.id).save
+    val vc = baseTestVenueClaim(v.id.get).save
 
     // eqs
-    metaRecordToQueryBuilder(Venue).where(_._id eqs v.id).fetch().map(_.id)                         must_== List(v.id)
-    Venue.where(_.mayor eqs v.mayor.value).fetch().map(_.id)              must_== List(v.id)
-    Venue.where(_.mayor eqs v.mayor.value).fetch().map(_.id)              must_== List(v.id)
-    Venue.where(_.venuename eqs v.venuename.value).fetch().map(_.id)      must_== List(v.id)
-    Venue.where(_.closed eqs false).fetch().map(_.id)                     must_== List(v.id)
+    metaRecordToQueryBuilder(Venue).where(_.id eqs v.id.get).fetch().map(_.id.get)                         must_== List(v.id.get)
+    Venue.where(_.mayor eqs v.mayor.value).fetch().map(_.id.get)              must_== List(v.id.get)
+    Venue.where(_.mayor eqs v.mayor.value).fetch().map(_.id.get)              must_== List(v.id.get)
+    Venue.where(_.venuename eqs v.venuename.value).fetch().map(_.id.get)      must_== List(v.id.get)
+    Venue.where(_.closed eqs false).fetch().map(_.id.get)                     must_== List(v.id.get)
 
-    Venue.where(_.mayor eqs 432432).fetch().map(_.id)                     must_== Nil
-    Venue.where(_.closed eqs true).fetch().map(_.id)                      must_== Nil
+    Venue.where(_.mayor eqs 432432).fetch().map(_.id.get)                     must_== Nil
+    Venue.where(_.closed eqs true).fetch().map(_.id.get)                      must_== Nil
 
-    VenueClaim.where(_.status eqs ClaimStatus.approved).fetch().map(_.id) must_== List(vc.id)
-    VenueClaim.where(_.venueid eqs v.id).fetch().map(_.id)                must_== List(vc.id)
-    VenueClaim.where(_.venueid eqs v).fetch().map(_.id)                   must_== List(vc.id)
+    VenueClaim.where(_.status eqs ClaimStatus.approved).fetch().map(_.id.get) must_== List(vc.id.get)
+    VenueClaim.where(_.venueid eqs v.id.get).fetch().map(_.id.get)                must_== List(vc.id.get)
+    VenueClaim.where(_.venueid eqs v).fetch().map(_.id.get)                   must_== List(vc.id.get)
   }
 
   @Test
   def testInequalityQueries: Unit = {
     val v = baseTestVenue().save
-    val vc = baseTestVenueClaim(v.id).save
+    val vc = baseTestVenueClaim(v.id.get).save
 
     // neq,lt,gt, where the lone Venue has mayor_count=3, and the only
     // VenueClaim has status approved.
-    Venue.where(_.mayor_count neqs 5).fetch().map(_.id)                     must_== List(v.id)
-    Venue.where(_.mayor_count < 5).fetch().map(_.id)                        must_== List(v.id)
-    Venue.where(_.mayor_count lt 5).fetch().map(_.id)                       must_== List(v.id)
-    Venue.where(_.mayor_count <= 5).fetch().map(_.id)                       must_== List(v.id)
-    Venue.where(_.mayor_count lte 5).fetch().map(_.id)                      must_== List(v.id)
-    Venue.where(_.mayor_count > 5).fetch().map(_.id)                        must_== Nil
-    Venue.where(_.mayor_count gt 5).fetch().map(_.id)                       must_== Nil
-    Venue.where(_.mayor_count >= 5).fetch().map(_.id)                       must_== Nil
-    Venue.where(_.mayor_count gte 5).fetch().map(_.id)                      must_== Nil
-    Venue.where(_.mayor_count between (3, 5)).fetch().map(_.id)             must_== List(v.id)
-    VenueClaim.where (_.status neqs ClaimStatus.approved).fetch().map(_.id) must_== Nil
-    VenueClaim.where (_.status neqs ClaimStatus.pending).fetch().map(_.id)  must_== List(vc.id)
+    Venue.where(_.mayor_count neqs 5).fetch().map(_.id.get)                     must_== List(v.id.get)
+    Venue.where(_.mayor_count < 5).fetch().map(_.id.get)                        must_== List(v.id.get)
+    Venue.where(_.mayor_count lt 5).fetch().map(_.id.get)                       must_== List(v.id.get)
+    Venue.where(_.mayor_count <= 5).fetch().map(_.id.get)                       must_== List(v.id.get)
+    Venue.where(_.mayor_count lte 5).fetch().map(_.id.get)                      must_== List(v.id.get)
+    Venue.where(_.mayor_count > 5).fetch().map(_.id.get)                        must_== Nil
+    Venue.where(_.mayor_count gt 5).fetch().map(_.id.get)                       must_== Nil
+    Venue.where(_.mayor_count >= 5).fetch().map(_.id.get)                       must_== Nil
+    Venue.where(_.mayor_count gte 5).fetch().map(_.id.get)                      must_== Nil
+    Venue.where(_.mayor_count between (3, 5)).fetch().map(_.id.get)             must_== List(v.id.get)
+    VenueClaim.where (_.status neqs ClaimStatus.approved).fetch().map(_.id.get) must_== Nil
+    VenueClaim.where (_.status neqs ClaimStatus.pending).fetch().map(_.id.get)  must_== List(vc.id.get)
   }
 
   @Test
   def selectQueries: Unit = {
     val v = baseTestVenue().save
 
-    val base = Venue.where(_._id eqs v.id)
+    val base = Venue.where(_.id eqs v.id.get)
     base.select(_.legacyid).fetch() must_== List(v.legacyid.value)
     base.select(_.legacyid, _.userid).fetch() must_== List((v.legacyid.value, v.userid.value))
     base.select(_.legacyid, _.userid, _.mayor).fetch() must_== List((v.legacyid.value, v.userid.value, v.mayor.value))
@@ -121,14 +121,14 @@ class EndToEndTest extends JUnitMustMatchers {
   @Test
   def selectEnum: Unit = {
     val v = baseTestVenue().save
-    Venue.where(_._id eqs v.id).select(_.status).fetch() must_== List(VenueStatus.open)
+    Venue.where(_.id eqs v.id.get).select(_.status).fetch() must_== List(VenueStatus.open)
   }
 
   @Test
   def selectCaseQueries: Unit = {
     val v = baseTestVenue().save
 
-    val base = Venue.where(_._id eqs v.id)
+    val base = Venue.where(_.id eqs v.id.get)
     base.selectCase(_.legacyid, V1).fetch() must_== List(V1(v.legacyid.value))
     base.selectCase(_.legacyid, _.userid, V2).fetch() must_== List(V2(v.legacyid.value, v.userid.value))
     base.selectCase(_.legacyid, _.userid, _.mayor, V3).fetch() must_== List(V3(v.legacyid.value, v.userid.value, v.mayor.value))
@@ -143,19 +143,19 @@ class EndToEndTest extends JUnitMustMatchers {
     val t = baseTestTip().save
 
     // select subfields
-    Tip.where(_._id eqs t.id).select(_.counts at "foo").fetch() must_== List(Some(1L))
+    Tip.where(_.id eqs t.id.get).select(_.counts at "foo").fetch() must_== List(Some(1L))
 
-    Venue.where(_._id eqs v.id).select(_.geolatlng.unsafeField[Double]("lat")).fetch() must_== List(Some(40.73))
+    Venue.where(_.id eqs v.id.get).select(_.geolatlng.unsafeField[Double]("lat")).fetch() must_== List(Some(40.73))
 
-    val subuserids: List[Option[List[Long]]] = Venue.where(_._id eqs v.id).select(_.claims.subselect(_.userid)).fetch()
+    val subuserids: List[Option[List[Long]]] = Venue.where(_.id eqs v.id.get).select(_.claims.subselect(_.userid)).fetch()
     subuserids must_== List(Some(List(1234, 5678)))
 
     // selecting a claims.userid when there is no top-level claims list should
     // have one element in the List for the one Venue, but an Empty for that
     // Venue since there's no list of claims there.
-    Venue.where(_._id eqs v.id).modify(_.claims unset).and(_.lastClaim unset).updateOne()
-    Venue.where(_._id eqs v.id).select(_.lastClaim.subselect(_.userid)).fetch() must_== List(None)
-    Venue.where(_._id eqs v.id).select(_.claims.subselect(_.userid)).fetch() must_== List(None)
+    Venue.where(_.id eqs v.id.get).modify(_.claims unset).and(_.lastClaim unset).updateOne()
+    Venue.where(_.id eqs v.id.get).select(_.lastClaim.subselect(_.userid)).fetch() must_== List(None)
+    Venue.where(_.id eqs v.id.get).select(_.claims.subselect(_.userid)).fetch() must_== List(None)
   }
 
   @Ignore("These tests are broken because DummyField doesn't know how to convert a String to an Enum")
@@ -167,14 +167,14 @@ class EndToEndTest extends JUnitMustMatchers {
     // know how to convert the String to an Enum.
 
     val statuses: List[Option[VenueClaimBson.status.MyType]] =
-          Venue.where(_._id eqs v.id).select(_.lastClaim.subselect(_.status)) .fetch()
+          Venue.where(_.id eqs v.id.get).select(_.lastClaim.subselect(_.status)) .fetch()
     // This assertion works.
     statuses must_== List(Some("Approved"))
     // This assertion is what we want, and it fails.
     // statuses must_== List(Some(ClaimStatus.approved))
 
     val subuseridsAndStatuses: List[(Option[List[Long]], Option[List[VenueClaimBson.status.MyType]])] =
-          Venue.where(_._id eqs v.id)
+          Venue.where(_.id eqs v.id.get)
                .select(_.claims.subselect(_.userid), _.claims.subselect(_.status))
                .fetch()
     // This assertion works.
@@ -192,9 +192,9 @@ class EndToEndTest extends JUnitMustMatchers {
     val v = baseTestVenue().save
 
     // eqs
-    Venue.where(_._id eqs v.id).fetch().map(_.id)                         must_== List(v.id)
-    Venue.where(_._id eqs v.id).setReadPreference(ReadPreference.secondary).fetch().map(_.id)        must_== List(v.id)
-    Venue.where(_._id eqs v.id).setReadPreference(ReadPreference.primary).fetch().map(_.id)       must_== List(v.id)
+    Venue.where(_.id eqs v.id.get).fetch().map(_.id.get)                         must_== List(v.id.get)
+    Venue.where(_.id eqs v.id.get).setReadPreference(ReadPreference.secondary).fetch().map(_.id.get)        must_== List(v.id.get)
+    Venue.where(_.id eqs v.id.get).setReadPreference(ReadPreference.primary).fetch().map(_.id.get)       must_== List(v.id.get)
   }
 
   @Test
@@ -223,12 +223,12 @@ class EndToEndTest extends JUnitMustMatchers {
   @Test
   def testRegexQuery {
     val v = baseTestVenue().save
-    Venue.where(_._id eqs v.id).and(_.venuename startsWith "test v").count must_== 1
-    Venue.where(_._id eqs v.id).and(_.venuename matches ".es. v".r).count must_== 1
-    Venue.where(_._id eqs v.id).and(_.venuename matches "Tes. v".r).count must_== 0
-    Venue.where(_._id eqs v.id).and(_.venuename matches Pattern.compile("Tes. v", Pattern.CASE_INSENSITIVE)).count must_== 1
-    Venue.where(_._id eqs v.id).and(_.venuename matches "test .*".r).and(_.legacyid in List(v.legacyid.value)).count must_== 1
-    Venue.where(_._id eqs v.id).and(_.venuename matches "test .*".r).and(_.legacyid nin List(v.legacyid.value)).count must_== 0
+    Venue.where(_.id eqs v.id.get).and(_.venuename startsWith "test v").count must_== 1
+    Venue.where(_.id eqs v.id.get).and(_.venuename matches ".es. v".r).count must_== 1
+    Venue.where(_.id eqs v.id.get).and(_.venuename matches "Tes. v".r).count must_== 0
+    Venue.where(_.id eqs v.id.get).and(_.venuename matches Pattern.compile("Tes. v", Pattern.CASE_INSENSITIVE)).count must_== 1
+    Venue.where(_.id eqs v.id.get).and(_.venuename matches "test .*".r).and(_.legacyid in List(v.legacyid.value)).count must_== 1
+    Venue.where(_.id eqs v.id.get).and(_.venuename matches "test .*".r).and(_.legacyid nin List(v.legacyid.value)).count must_== 0
     Venue.where(_.tags matches """some\s.*""".r).count must_== 1
   }
 
@@ -238,9 +238,9 @@ class EndToEndTest extends JUnitMustMatchers {
     val vs = for (i <- 1 to 10) yield {
       baseTestVenue().legacyid(i).save
     }
-    val ids = vs.map(_.id)
+    val ids = vs.map(_.id.get)
 
-    val items1 = Venue.where(_._id in ids)
+    val items1 = Venue.where(_.id in ids)
         .iterate[List[Venue]](Nil){ case (accum, event) => {
       if (accum.length >= 3) {
         Return(accum)
@@ -256,7 +256,7 @@ class EndToEndTest extends JUnitMustMatchers {
 
     items1.map(_.legacyid.value) must_== List(6, 4, 2)
 
-    val items2 = Venue.where(_._id in ids)
+    val items2 = Venue.where(_.id in ids)
         .iterateBatch[List[Venue]](2, Nil){ case (accum, event) => {
       if (accum.length >= 3) {
         Return(accum)
@@ -274,7 +274,7 @@ class EndToEndTest extends JUnitMustMatchers {
     items2.map(_.legacyid.value) must_== List(1, 4, 7)
 
     def findIndexOfWithLimit(id: Long, limit: Int) = {
-      Venue.where(_._id in ids).iterate(1){ case (idx, event) => {
+      Venue.where(_.id in ids).iterate(1){ case (idx, event) => {
         if (idx >= limit) {
           Return(-1)
         } else {
@@ -330,14 +330,14 @@ class EndToEndTest extends JUnitMustMatchers {
 
     // Modify
     Like.withShardKey(_.userid eqs 2).and(_.checkin eqs 333).modify(_.checkin setTo 334).updateOne()
-    Like.find(l3.id).open_!.checkin.value must_== 334
+    Like.find(l3.id.get).open_!.checkin.value must_== 334
     Like.where(_.checkin eqs 334).allShards.count() must_== 1
 
     Like.where(_.checkin eqs 111).allShards.modify(_.checkin setTo 112).updateMulti()
     Like.where(_.checkin eqs 112).withShardKey(_.userid in List(1L, 2L)).count() must_== 2
 
     val l5 = Like.where(_.checkin eqs 112).withShardKey(_.userid eqs 1).findAndModify(_.checkin setTo 113).updateOne(returnNew = true)
-    l5.get.id must_== l1.id
+    l5.get.id.get must_== l1.id.get
     l5.get.checkin.value must_== 113
   }
 
@@ -345,7 +345,7 @@ class EndToEndTest extends JUnitMustMatchers {
   def testLimitAndBatch {
     (1 to 50).foreach(_ => baseTestVenue().save)
 
-    val q = Venue.select(_._id)
+    val q = Venue.select(_.id)
     q.limit(10).fetch().length must_== 10
     q.limit(-10).fetch().length must_== 10
     q.fetchBatch(20)(x => List(x.length)) must_== List(20, 20, 10)
@@ -356,7 +356,7 @@ class EndToEndTest extends JUnitMustMatchers {
   @Test
   def testCount {
     (1 to 10).foreach(_ => baseTestVenue().save)
-    val q = Venue.select(_._id)
+    val q = Venue.select(_.id)
     q.count() must_== 10
     q.limit(3).count() must_== 3
     q.limit(15).count() must_== 10

--- a/rogue-lift/src/test/scala/com/foursquare/rogue/IndexCheckerTest.scala
+++ b/rogue-lift/src/test/scala/com/foursquare/rogue/IndexCheckerTest.scala
@@ -16,7 +16,7 @@ import org.junit._
 import org.specs2.matcher.JUnitMustMatchers
 
 
-class TestModel extends MongoRecord[TestModel] with MongoId[TestModel] {
+class TestModel extends MongoRecord[TestModel] with ObjectIdPk[TestModel] {
   def meta = TestModel
   object a extends IntField(this)
   object b extends IntField(this)
@@ -32,7 +32,7 @@ object TestModel extends TestModel with MongoMetaRecord[TestModel] with IndexedR
   override def collectionName = "model"
 
   override val mongoIndexList = List(
-    TestModel.index(_._id, Asc),
+    TestModel.index(_.id, Asc),
     TestModel.index(_.a, Asc, _.b, Asc, _.c, Asc),
     TestModel.index(_.m, Asc, _.a, Asc),
     TestModel.index(_.l, Asc),
@@ -172,11 +172,11 @@ class MongoIndexCheckerTest extends JUnitMustMatchers {
     // Overspecifed queries
     val id = new ObjectId
     val d = new DateTime
-    yes(TestModel where (_._id eqs id) and (_.d eqs 4))
-    yes(TestModel where (_._id in List(id)) and (_.d eqs 4))
-    no(TestModel where (_._id after d) scan (_.d eqs 4))
-    no(TestModel iscan (_._id after d) iscan (_.d eqs 4))
-    yes(TestModel iscan (_._id after d) scan (_.d eqs 4))
+    yes(TestModel where (_.id eqs id) and (_.d eqs 4))
+    yes(TestModel where (_.id in List(id)) and (_.d eqs 4))
+    no(TestModel where (_.id after d) scan (_.d eqs 4))
+    no(TestModel iscan (_.id after d) iscan (_.d eqs 4))
+    yes(TestModel iscan (_.id after d) scan (_.d eqs 4))
 
     // Multikeys
     yes(TestModel scan (_.m at "foo" eqs 2))

--- a/rogue-lift/src/test/scala/com/foursquare/rogue/QueryExecutorTest.scala
+++ b/rogue-lift/src/test/scala/com/foursquare/rogue/QueryExecutorTest.scala
@@ -4,11 +4,12 @@ package com.foursquare.rogue
 import org.junit._
 import org.specs2.matcher.JUnitMustMatchers
 import com.foursquare.rogue.MongoHelpers.AndCondition
-import net.liftweb.mongodb.record.{MongoId, MongoRecord, MongoMetaRecord}
+import net.liftweb.mongodb.record.{MongoRecord, MongoMetaRecord}
+import net.liftweb.mongodb.record.field.ObjectIdPk
 
 class LegacyQueryExecutorTest extends JUnitMustMatchers {
 
-  class Dummy extends MongoRecord[Dummy] with MongoId[Dummy] {
+  class Dummy extends MongoRecord[Dummy] with ObjectIdPk[Dummy] {
     def meta = Dummy
   }
 

--- a/rogue-lift/src/test/scala/com/foursquare/rogue/QueryTest.scala
+++ b/rogue-lift/src/test/scala/com/foursquare/rogue/QueryTest.scala
@@ -24,17 +24,17 @@ class QueryTest extends JUnitMustMatchers {
     val oid1 = new ObjectId(d1.toDate, 0, 0)
     val oid2 = new ObjectId(d2.toDate, 0, 0)
     val oid = new ObjectId
-    val ven1 = Venue.createRecord._id(oid1)
+    val ven1 = Venue.createRecord.id(oid1)
 
     // eqs
     Venue.where(_.mayor eqs 1)              .toString() must_== """db.venues.find({ "mayor" : 1})"""
     Venue.where(_.venuename eqs "Starbucks").toString() must_== """db.venues.find({ "venuename" : "Starbucks"})"""
     Venue.where(_.closed eqs true)          .toString() must_== """db.venues.find({ "closed" : true})"""
-    Venue.where(_._id eqs oid)              .toString() must_== ("""db.venues.find({ "_id" : { "$oid" : "%s"}})""" format oid.toString)
+    Venue.where(_.id eqs oid)              .toString() must_== ("""db.venues.find({ "_id" : { "$oid" : "%s"}})""" format oid.toString)
     VenueClaim.where(_.status eqs ClaimStatus.approved).toString() must_== """db.venueclaims.find({ "status" : "Approved"})"""
 
     VenueClaim.where(_.venueid eqs oid)     .toString() must_== ("""db.venueclaims.find({ "vid" : { "$oid" : "%s"}})""" format oid.toString)
-    VenueClaim.where(_.venueid eqs ven1.id) .toString() must_== ("""db.venueclaims.find({ "vid" : { "$oid" : "%s"}})""" format oid1.toString)
+    VenueClaim.where(_.venueid eqs ven1.id.get) .toString() must_== ("""db.venueclaims.find({ "vid" : { "$oid" : "%s"}})""" format oid1.toString)
     VenueClaim.where(_.venueid eqs ven1)    .toString() must_== ("""db.venueclaims.find({ "vid" : { "$oid" : "%s"}})""" format oid1.toString)
 
     // neq,lt,gt
@@ -66,15 +66,15 @@ class QueryTest extends JUnitMustMatchers {
     VenueClaim.where(_.status in List(ClaimStatus.approved, ClaimStatus.pending)) .toString() must_== """db.venueclaims.find({ "status" : { "$in" : [ "Approved" , "Pending approval"]}})"""
     VenueClaim.where(_.status nin List(ClaimStatus.approved, ClaimStatus.pending)).toString() must_== """db.venueclaims.find({ "status" : { "$nin" : [ "Approved" , "Pending approval"]}})"""
 
-    VenueClaim.where(_.venueid in List(ven1.id)) .toString() must_== ("""db.venueclaims.find({ "vid" : { "$in" : [ { "$oid" : "%s"}]}})""" format oid1.toString)
+    VenueClaim.where(_.venueid in List(ven1.id.get)) .toString() must_== ("""db.venueclaims.find({ "vid" : { "$in" : [ { "$oid" : "%s"}]}})""" format oid1.toString)
     VenueClaim.where(_.venueid in List(ven1))    .toString() must_== ("""db.venueclaims.find({ "vid" : { "$in" : [ { "$oid" : "%s"}]}})""" format oid1.toString)
 
-    VenueClaim.where(_.venueid nin List(ven1.id))  .toString() must_== ("""db.venueclaims.find({ "vid" : { "$nin" : [ { "$oid" : "%s"}]}})""" format oid1.toString)
+    VenueClaim.where(_.venueid nin List(ven1.id.get))  .toString() must_== ("""db.venueclaims.find({ "vid" : { "$nin" : [ { "$oid" : "%s"}]}})""" format oid1.toString)
     VenueClaim.where(_.venueid nin List(ven1))     .toString() must_== ("""db.venueclaims.find({ "vid" : { "$nin" : [ { "$oid" : "%s"}]}})""" format oid1.toString)
 
 
     // exists
-    Venue.where(_._id exists true).toString() must_== """db.venues.find({ "_id" : { "$exists" : true}})"""
+    Venue.where(_.id exists true).toString() must_== """db.venues.find({ "_id" : { "$exists" : true}})"""
 
     // startsWith, regex
     Venue.where(_.venuename startsWith "Starbucks").toString() must_== """db.venues.find({ "venuename" : { "$regex" : "^\\QStarbucks\\E" , "$options" : ""}})"""
@@ -118,10 +118,10 @@ class QueryTest extends JUnitMustMatchers {
     Venue.where(_.geolatlng nearSphere (39.0, -74.0, Radians(1.0))).toString() must_== """db.venues.find({ "latlng" : { "$nearSphere" : [ 39.0 , -74.0] , "$maxDistance" : 1.0}})"""
 
     // ObjectId before, after, between
-    Venue.where(_._id before d2)       .toString() must_== """db.venues.find({ "_id" : { "$lt" : { "$oid" : "%s"}}})""".format(oid2.toString)
-    Venue.where(_._id after d1)        .toString() must_== """db.venues.find({ "_id" : { "$gt" : { "$oid" : "%s"}}})""".format(oid1.toString)
-    Venue.where(_._id between (d1, d2)).toString() must_== """db.venues.find({ "_id" : { "$gt" : { "$oid" : "%s"} , "$lt" : { "$oid" : "%s"}}})""".format(oid1.toString, oid2.toString)
-    Venue.where(_._id between Tuple2(d1, d2)).toString() must_== """db.venues.find({ "_id" : { "$gt" : { "$oid" : "%s"} , "$lt" : { "$oid" : "%s"}}})""".format(oid1.toString, oid2.toString)
+    Venue.where(_.id before d2)       .toString() must_== """db.venues.find({ "_id" : { "$lt" : { "$oid" : "%s"}}})""".format(oid2.toString)
+    Venue.where(_.id after d1)        .toString() must_== """db.venues.find({ "_id" : { "$gt" : { "$oid" : "%s"}}})""".format(oid1.toString)
+    Venue.where(_.id between (d1, d2)).toString() must_== """db.venues.find({ "_id" : { "$gt" : { "$oid" : "%s"} , "$lt" : { "$oid" : "%s"}}})""".format(oid1.toString, oid2.toString)
+    Venue.where(_.id between Tuple2(d1, d2)).toString() must_== """db.venues.find({ "_id" : { "$gt" : { "$oid" : "%s"} , "$lt" : { "$oid" : "%s"}}})""".format(oid1.toString, oid2.toString)
 
     // DateTime before, after, between
     Venue.where(_.last_updated before d2)       .toString() must_== """db.venues.find({ "last_updated" : { "$lt" : { "$date" : "2010-05-02T00:00:00.000Z"}}})"""
@@ -159,7 +159,7 @@ class QueryTest extends JUnitMustMatchers {
 
     // queries with no clauses
     metaRecordToQueryBuilder(Venue).toString() must_== "db.venues.find({ })"
-    Venue.orderDesc(_._id).toString() must_== """db.venues.find({ }).sort({ "_id" : -1})"""
+    Venue.orderDesc(_.id).toString() must_== """db.venues.find({ }).sort({ "_id" : -1})"""
 
     // ordered queries
     Venue.where(_.mayor eqs 1).orderAsc(_.legacyid).toString() must_== """db.venues.find({ "mayor" : 1}).sort({ "legid" : 1})"""
@@ -207,8 +207,8 @@ class QueryTest extends JUnitMustMatchers {
 
     // out of order and doesn't screw up earlier params
     Venue.limit(10).where(_.mayor eqs 1).toString() must_== """db.venues.find({ "mayor" : 1}).limit(10)"""
-    Venue.orderDesc(_._id).and(_.mayor eqs 1).toString() must_== """db.venues.find({ "mayor" : 1}).sort({ "_id" : -1})"""
-    Venue.orderDesc(_._id).skip(3).and(_.mayor eqs 1).toString() must_== """db.venues.find({ "mayor" : 1}).sort({ "_id" : -1}).skip(3)"""
+    Venue.orderDesc(_.id).and(_.mayor eqs 1).toString() must_== """db.venues.find({ "mayor" : 1}).sort({ "_id" : -1})"""
+    Venue.orderDesc(_.id).skip(3).and(_.mayor eqs 1).toString() must_== """db.venues.find({ "mayor" : 1}).sort({ "_id" : -1}).skip(3)"""
 
     // Scan should be the same as and/where
     Venue.where(_.mayor eqs 1).scan(_.tags contains "karaoke").toString() must_== """db.venues.find({ "mayor" : 1 , "tags" : "karaoke"})"""
@@ -335,12 +335,12 @@ class QueryTest extends JUnitMustMatchers {
     Venue.where(_.mayor eqs 1)              .signature() must_== """db.venues.find({ "mayor" : 0})"""
     Venue.where(_.venuename eqs "Starbucks").signature() must_== """db.venues.find({ "venuename" : 0})"""
     Venue.where(_.closed eqs true)          .signature() must_== """db.venues.find({ "closed" : 0})"""
-    Venue.where(_._id eqs oid)              .signature() must_== """db.venues.find({ "_id" : 0})"""
+    Venue.where(_.id eqs oid)              .signature() must_== """db.venues.find({ "_id" : 0})"""
     VenueClaim.where(_.status eqs ClaimStatus.approved).signature() must_== """db.venueclaims.find({ "status" : 0})"""
     Venue.where(_.mayor_count gte 5).signature() must_== """db.venues.find({ "mayor_count" : { "$gte" : 0}})"""
     VenueClaim.where(_.status neqs ClaimStatus.approved).signature() must_== """db.venueclaims.find({ "status" : { "$ne" : 0}})"""
     Venue.where(_.legacyid in List(123L, 456L)).signature() must_== """db.venues.find({ "legid" : { "$in" : 0}})"""
-    Venue.where(_._id exists true).signature() must_== """db.venues.find({ "_id" : { "$exists" : 0}})"""
+    Venue.where(_.id exists true).signature() must_== """db.venues.find({ "_id" : { "$exists" : 0}})"""
     Venue.where(_.venuename startsWith "Starbucks").signature() must_== """db.venues.find({ "venuename" : { "$regex" : 0 , "$options" : 0}})"""
 
     // list
@@ -365,7 +365,7 @@ class QueryTest extends JUnitMustMatchers {
     Venue.where(_.geolatlng nearSphere (39.0, -74.0, Radians(1.0)))    .signature() must_== """db.venues.find({ "latlng" : { "$nearSphere" : 0 , "$maxDistance" : 0}})"""
 
     // id, date range
-    Venue.where(_._id before d2).signature()          must_== """db.venues.find({ "_id" : { "$lt" : 0}})"""
+    Venue.where(_.id before d2).signature()          must_== """db.venues.find({ "_id" : { "$lt" : 0}})"""
     Venue.where(_.last_updated before d2).signature() must_== """db.venues.find({ "last_updated" : { "$lt" : 0}})"""
 
     // Case class list field
@@ -388,7 +388,7 @@ class QueryTest extends JUnitMustMatchers {
 
     // queries with no clauses
     metaRecordToQueryBuilder(Venue).signature() must_== "db.venues.find({ })"
-    Venue.orderDesc(_._id)         .signature() must_== """db.venues.find({ }).sort({ "_id" : -1})"""
+    Venue.orderDesc(_.id)         .signature() must_== """db.venues.find({ }).sort({ "_id" : -1})"""
 
     // ordered queries
     Venue.where(_.mayor eqs 1).orderAsc(_.legacyid).signature() must_== """db.venues.find({ "mayor" : 0}).sort({ "legid" : 1})"""
@@ -401,7 +401,7 @@ class QueryTest extends JUnitMustMatchers {
     Venue.where(_.mayor eqs 1).scan(_.tags contains "karaoke").signature() must_== """db.venues.find({ "mayor" : 0 , "tags" : 0})"""
 
     // or queries
-    Venue.where(_.mayor eqs 1).or(_.where(_._id eqs oid)).signature() must_== """db.venues.find({ "mayor" : 0 , "$or" : [ { "_id" : 0}]})"""
+    Venue.where(_.mayor eqs 1).or(_.where(_.id eqs oid)).signature() must_== """db.venues.find({ "mayor" : 0 , "$or" : [ { "_id" : 0}]})"""
   }
 
   @Test

--- a/rogue-lift/src/test/scala/com/foursquare/rogue/TestModels.scala
+++ b/rogue-lift/src/test/scala/com/foursquare/rogue/TestModels.scala
@@ -38,7 +38,7 @@ object VenueStatus extends Enumeration {
   val closed = Value("Closed")
 }
 
-class Venue extends MongoRecord[Venue] with MongoId[Venue] with IndexedRecord[Venue] {
+class Venue extends MongoRecord[Venue] with ObjectIdPk[Venue] with IndexedRecord[Venue] {
   def meta = Venue
   object legacyid extends LongField(this) { override def name = "legid" }
   object userid extends LongField(this)
@@ -60,9 +60,9 @@ object Venue extends Venue with MongoMetaRecord[Venue] {
   override def mongoIdentifier = RogueTestMongo
 
   object CustomIndex extends IndexModifier("custom")
-  val idIdx = Venue.index(_._id, Asc)
-  val mayorIdIdx = Venue.index(_.mayor, Asc, _._id, Asc)
-  val mayorIdClosedIdx = Venue.index(_.mayor, Asc, _._id, Asc, _.closed, Asc)
+  val idIdx = Venue.index(_.id, Asc)
+  val mayorIdIdx = Venue.index(_.mayor, Asc, _.id, Asc)
+  val mayorIdClosedIdx = Venue.index(_.mayor, Asc, _.id, Asc, _.closed, Asc)
   val legIdx = Venue.index(_.legacyid, Desc)
   val geoIdx = Venue.index(_.geolatlng, TwoD)
   val geoCustomIdx = Venue.index(_.geolatlng, CustomIndex, _.tags, Asc)
@@ -87,7 +87,7 @@ object RejectReason extends Enumeration {
   val wrongCode = Value("wrong code")
 }
 
-class VenueClaim extends MongoRecord[VenueClaim] with MongoId[VenueClaim] with Venue.FK[VenueClaim] {
+class VenueClaim extends MongoRecord[VenueClaim] with ObjectIdPk[VenueClaim] with Venue.FK[VenueClaim] {
   def meta = VenueClaim
   object userid extends LongField(this) { override def name = "uid" }
   object status extends EnumNameField(this, ClaimStatus)
@@ -95,7 +95,7 @@ class VenueClaim extends MongoRecord[VenueClaim] with MongoId[VenueClaim] with V
   object date extends DateField(this)
 }
 object VenueClaim extends VenueClaim with MongoMetaRecord[VenueClaim] {
-  override def fieldOrder = List(status, _id, userid, venueid, reason)
+  override def fieldOrder = List(status, id, userid, venueid, reason)
   override def collectionName = "venueclaims"
   override def mongoIdentifier = RogueTestMongo
 }
@@ -121,7 +121,7 @@ object SourceBson extends SourceBson with BsonMetaRecord[SourceBson] {
 }
 
 case class OneComment(timestamp: String, userid: Long, comment: String)
-class Comment extends MongoRecord[Comment] with MongoId[Comment] {
+class Comment extends MongoRecord[Comment] with ObjectIdPk[Comment] {
   def meta = Comment
   object comments extends MongoCaseClassListField[Comment, OneComment](this)
 }
@@ -129,10 +129,10 @@ object Comment extends Comment with MongoMetaRecord[Comment] {
   override def collectionName = "comments"
   override def mongoIdentifier = RogueTestMongo
 
-  val idx1 = Comment.index(_._id, Asc)
+  val idx1 = Comment.index(_.id, Asc)
 }
 
-class Tip extends MongoRecord[Tip] with MongoId[Tip] {
+class Tip extends MongoRecord[Tip] with ObjectIdPk[Tip] {
   def meta = Tip
   object legacyid extends LongField(this) { override def name = "legid" }
   object counts extends MongoMapField[Tip, Long](this)
@@ -143,7 +143,7 @@ object Tip extends Tip with MongoMetaRecord[Tip] {
   override def mongoIdentifier = RogueTestMongo
 }
 
-class Like extends MongoRecord[Like] with MongoId[Like] with Sharded {
+class Like extends MongoRecord[Like] with ObjectIdPk[Like] with Sharded {
   def meta = Like
   object userid extends LongField(this) with ShardKey[Long]
   object checkin extends LongField(this)
@@ -158,7 +158,7 @@ object ConsumerPrivilege extends Enumeration {
   val awardBadges = Value("Award badges")
 }
 
-class OAuthConsumer extends MongoRecord[OAuthConsumer] with MongoId[OAuthConsumer] {
+class OAuthConsumer extends MongoRecord[OAuthConsumer] with ObjectIdPk[OAuthConsumer] {
   def meta = OAuthConsumer
   object privileges extends MongoListField[OAuthConsumer, ConsumerPrivilege.Value](this)
 }


### PR DESCRIPTION
I'm hoping to remove MongoId in Lift 2.6, so I wanted to get this updated.

Are you guys still using lift-mongo-record at all? Hopefully this won't affect you, it can be a messy upgrade.
