### PR TITLE
Removed open_! method from LiftRogue.

### DIFF
--- a/rogue-lift/src/main/scala/com/foursquare/rogue/LiftRogue.scala
+++ b/rogue-lift/src/main/scala/com/foursquare/rogue/LiftRogue.scala
@@ -10,6 +10,7 @@ import com.foursquare.index.IndexBuilder
 import com.foursquare.rogue.MongoHelpers.{AndCondition, MongoModify}
 import java.util.Date
 import net.liftweb.json.JsonAST.{JArray, JInt}
+import net.liftweb.common.Box.box2Option
 import net.liftweb.mongodb.record.{BsonRecord, MongoRecord, MongoMetaRecord}
 import net.liftweb.record.{Field, MandatoryTypedField, OptionalTypedField, Record}
 import net.liftweb.mongodb.record.field.{ BsonRecordField, BsonRecordListField, MongoCaseClassField,
@@ -103,7 +104,7 @@ trait LiftRogue extends Rogue {
       val field = owner.fieldByName(fieldName).openOr(sys.error("Error getting field "+fieldName+" for "+owner))
       val typedField = field.asInstanceOf[BsonRecordListField[M, B]]
        // a gross hack to get at the embedded record
-      val rec: B = typedField.setFromJValue(JArray(JInt(0) :: Nil)).open_!.head
+      val rec: B = typedField.setFromJValue(JArray(JInt(0) :: Nil)).get.head
       new BsonRecordQueryField[M, B](f, _.asDBObject, rec)
     } else {
       val fieldName = f.name
@@ -118,7 +119,7 @@ trait LiftRogue extends Rogue {
       M <: BsonRecord[M],
       B <: BsonRecord[B]
   ](f: BsonRecordListField[M, B]): BsonRecordListQueryField[M, B] = {
-    val rec = f.setFromJValue(JArray(JInt(0) :: Nil)).open_!.head // a gross hack to get at the embedded record
+    val rec = f.setFromJValue(JArray(JInt(0) :: Nil)).get.head // a gross hack to get at the embedded record
     new BsonRecordListQueryField[M, B](f, rec, _.asDBObject)
   }
 
@@ -194,7 +195,7 @@ trait LiftRogue extends Rogue {
   )(
       implicit mf: Manifest[B]
   ): BsonRecordListModifyField[M, B] = {
-    val rec = f.setFromJValue(JArray(JInt(0) :: Nil)).open_!.head // a gross hack to get at the embedded record
+    val rec = f.setFromJValue(JArray(JInt(0) :: Nil)).get.head // a gross hack to get at the embedded record
     new BsonRecordListModifyField[M, B](f, rec, _.asDBObject)(mf)
   }
 


### PR DESCRIPTION
- The `open_!` method is deprecated in the latest versions of Lift and completely removed from 3.0.
- `box2Option` is consistent in all versions of Lift from 2.2 to 3.0-SNAPSHOT.
- The hack is just as gross as the existing one.
- Gets embedded records working in 3.0.
