### PR TITLE
Pass indexes to QueryHelpers.validator.validate*

### DIFF
--- a/rogue-core/src/main/scala/com/foursquare/rogue/QueryHelpers.scala
+++ b/rogue-core/src/main/scala/com/foursquare/rogue/QueryHelpers.scala
@@ -53,17 +53,17 @@ object QueryHelpers {
   trait QueryValidator {
     def validateList[T](xs: Traversable[T]): Unit
     def validateRadius(d: Degrees): Degrees
-    def validateQuery[M](query: Query[M, _, _]): Unit
-    def validateModify[M](modify: ModifyQuery[M, _]): Unit
-    def validateFindAndModify[M, R](modify: FindAndModifyQuery[M, R]): Unit
+    def validateQuery[M](query: Query[M, _, _], indexes: Option[List[MongoIndex[_]]]): Unit
+    def validateModify[M](modify: ModifyQuery[M, _], indexes: Option[List[MongoIndex[_]]]): Unit
+    def validateFindAndModify[M, R](modify: FindAndModifyQuery[M, R], indexes: Option[List[MongoIndex[_]]]): Unit
   }
 
   class DefaultQueryValidator extends QueryValidator {
     override def validateList[T](xs: Traversable[T]) {}
     override def validateRadius(d: Degrees) = d
-    override def validateQuery[M](query: Query[M, _, _]) {}
-    override def validateModify[M](modify: ModifyQuery[M, _]) {} // todo possibly validate for update without upsert, yet setOnInsert present -- ktoso
-    override def validateFindAndModify[M, R](modify: FindAndModifyQuery[M, R]) {}
+    override def validateQuery[M](query: Query[M, _, _], indexes: Option[List[MongoIndex[_]]]) {}
+    override def validateModify[M](modify: ModifyQuery[M, _], indexes: Option[List[MongoIndex[_]]]) {} // todo possibly validate for update without upsert, yet setOnInsert present -- ktoso
+    override def validateFindAndModify[M, R](modify: FindAndModifyQuery[M, R], indexes: Option[List[MongoIndex[_]]]) {}
   }
 
   object NoopQueryValidator extends DefaultQueryValidator

--- a/rogue-core/src/test/scala/com/foursquare/rogue/TrivialORMQueryTest.scala
+++ b/rogue-core/src/test/scala/com/foursquare/rogue/TrivialORMQueryTest.scala
@@ -1,5 +1,6 @@
 package com.foursquare.rogue
 
+import com.foursquare.index.MongoIndex
 import com.foursquare.field.{Field, OptionalField}
 import com.mongodb.{DB, DBCollection, DBObject, Mongo, ServerAddress, WriteConcern}
 import com.foursquare.rogue.MongoHelpers.{AndCondition, MongoModify, MongoSelect}
@@ -35,6 +36,9 @@ object TrivialORM {
     }
     override def getInstanceName[M <: MB](query: Query[M, _, _]): String = {
       db.getName
+    }
+    override def getIndexes[M <: MB](query: Query[M, _, _]): Option[List[MongoIndex[_]]] = {
+      None
     }
   }
 

--- a/rogue-lift/src/main/scala/com/foursquare/rogue/LiftQueryExecutor.scala
+++ b/rogue-lift/src/main/scala/com/foursquare/rogue/LiftQueryExecutor.scala
@@ -2,15 +2,16 @@
 
 package com.foursquare.rogue
 
+import com.foursquare.index.{MongoIndex, IndexedRecord}
 import com.foursquare.rogue.MongoHelpers.MongoSelect
+import com.mongodb.{DBCollection, DBObject}
 import net.liftweb.common.{Box, Full}
 import net.liftweb.mongodb.record.{BsonRecord, BsonMetaRecord, MongoRecord, MongoMetaRecord}
-import org.bson.types.BasicBSONList
 import net.liftweb.mongodb.MongoDB
-import com.mongodb.{DBCollection, DBObject}
-import sun.reflect.generics.reflectiveObjects.NotImplementedException
 import net.liftweb.mongodb.record.field.BsonRecordField
 import net.liftweb.record.Record
+import org.bson.types.BasicBSONList
+import sun.reflect.generics.reflectiveObjects.NotImplementedException
 
 object LiftDBCollectionFactory extends DBCollectionFactory[MongoRecord[_] with MongoMetaRecord[_]] {
   override def getDBCollection[M <: MongoRecord[_] with MongoMetaRecord[_]](query: Query[M, _, _]): DBCollection = {
@@ -25,6 +26,21 @@ object LiftDBCollectionFactory extends DBCollectionFactory[MongoRecord[_] with M
   }
   override def getInstanceName[M <: MongoRecord[_] with MongoMetaRecord[_]](query: Query[M, _, _]): String = {
     query.meta.mongoIdentifier.toString
+  }
+
+  /**
+   * Retrieves the list of indexes declared for the record type associated with a
+   * query. If the record type doesn't declare any indexes, then returns None.
+   * @param query the query
+   * @return the list of indexes, or an empty list.
+   */
+  override def getIndexes[M <: MongoRecord[_] with MongoMetaRecord[_]](query: Query[M, _, _]): Option[List[MongoIndex[_]]] = {
+    val queryMetaRecord = query.meta
+    if (queryMetaRecord.isInstanceOf[IndexedRecord[_]]) {
+      Some(queryMetaRecord.asInstanceOf[IndexedRecord[_]].mongoIndexList)
+    } else {
+      None
+    }
   }
 }
 

--- a/rogue-lift/src/test/scala/com/foursquare/rogue/IndexCheckerTest.scala
+++ b/rogue-lift/src/test/scala/com/foursquare/rogue/IndexCheckerTest.scala
@@ -45,7 +45,8 @@ class MongoIndexCheckerTest extends JUnitMustMatchers {
   def testIndexExpectations {
     def test(query: Query[_, _, _]) = {
       val q = query.asInstanceOf[Query[_, _, _]]
-      MongoIndexChecker.validateIndexExpectations(q)
+      val indexes = q.meta.asInstanceOf[IndexedRecord[_]].mongoIndexList
+      MongoIndexChecker.validateIndexExpectations(q, indexes)
     }
 
     def yes(query: Query[_, _, _]) =
@@ -95,8 +96,9 @@ class MongoIndexCheckerTest extends JUnitMustMatchers {
   def testMatchesIndex {
     def test(query: Query[_, _, _]) = {
       val q = query.asInstanceOf[Query[_, _, _]]
-      MongoIndexChecker.validateIndexExpectations(q) &&
-        MongoIndexChecker.validateQueryMatchesSomeIndex(q)
+      val indexes = q.meta.asInstanceOf[IndexedRecord[_]].mongoIndexList
+      MongoIndexChecker.validateIndexExpectations(q, indexes) &&
+        MongoIndexChecker.validateQueryMatchesSomeIndex(q, indexes)
     }
 
     def yes(query: Query[_, _, _]) =


### PR DESCRIPTION
- MongoJavaDriver gets indexes from DBCollectionFactory impl
  this allows list of indexes to be generated by an
  backend that is implementation specific to the model
  type
- this will allow a DBCollectionFactory for spindle to
  return indexes without spindle depending on rogue-index
- NOTE: this changes the interface of:
  DBCollectionFactory (new abstract method getIndexes)
  QueryHelpers.QueryValidator (indexes params)
  MongoIndexChecker (validate methods w/o indexes param
    removed, getIndexes removed)
  New trait IndexChecker to make public interface more clear
