### PR TITLE
Specified sbt version 0.12.4 for the purpose of building in Travis CI

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.12.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += Resolver.url("scalasbt", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))  (Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.jsuereth" % "xsbt-gpg-plugin" % "0.6")
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
-addSbtPlugin("com.foursquare" % "spindle-codegen-plugin" % "1.7.0")
+addSbtPlugin("com.foursquare" % "spindle-codegen-plugin" % "1.8.3")
 
 scalacOptions ++= Seq("-deprecation", "-unchecked")


### PR DESCRIPTION
It looks like Travis CI use sbt 0.13.0 now when it was specified without sbt version.
This is why fail build in Travis CI.
So, I specified sbt version using build.properties.

I wanted to set latest version 0.13.2, but I cannot find correspond spindle-codegen-plugin.
So, set 0.12.4.

I have confirmed the build success at my repository.

https://travis-ci.org/zaneli/rogue/builds/23980579
[![Build Status](https://travis-ci.org/zaneli/rogue.png?branch=sbt-0.12.4)](https://travis-ci.org/zaneli/rogue)
