### PR TITLE
Add `setTo(vsOpt: Option[Traversable[V]])` to ListModifyField

### DIFF
--- a/rogue-core/src/main/scala/com/foursquare/rogue/QueryField.scala
+++ b/rogue-core/src/main/scala/com/foursquare/rogue/QueryField.scala
@@ -445,6 +445,18 @@ abstract class AbstractListModifyField[V, DB, M, CC[X] <: Seq[X]](val field: Fie
     new ModifyClause(ModOps.Set,
                      field.name -> QueryHelpers.list(valuesToDB(vs)))
 
+  def setTo(vsOpt: Option[Traversable[V]]) = {
+    vsOpt match {
+      case Some(vs) => {
+        new ModifyClause(ModOps.Set,
+                         field.name -> QueryHelpers.list(valuesToDB(vs)))
+      }
+      case None => {
+        new SafeModifyField(field).unset
+      }
+    }
+  }
+
   def push(v: V) =
     new ModifyClause(ModOps.Push,
                      field.name -> valueToDB(v))

--- a/rogue-lift/src/test/scala/com/foursquare/rogue/QueryTest.scala
+++ b/rogue-lift/src/test/scala/com/foursquare/rogue/QueryTest.scala
@@ -265,7 +265,10 @@ class QueryTest extends JUnitMustMatchers {
     Venue.where(_.legacyid eqs 1).modify(_.geolatlng setTo ll).toString() must_== query + """{ "$set" : { "latlng" : [ 37.4 , -73.9]}}""" + suffix
 
     // Lists
-    Venue.where(_.legacyid eqs 1).modify(_.popularity setTo List(5))      .toString() must_== query + """{ "$set" : { "popularity" : [ 5]}}""" + suffix
+    Venue.where(_.legacyid eqs 1).modify(_.popularity setTo List(5L))     .toString() must_== query + """{ "$set" : { "popularity" : [ 5]}}""" + suffix
+    Venue.where(_.legacyid eqs 1).modify(_.popularity unset)              .toString() must_== query + """{ "$unset" : { "popularity" : 1}}""" + suffix
+    Venue.where(_.legacyid eqs 1).modify(_.popularity setTo Some(List(5L))).toString() must_== query + """{ "$set" : { "popularity" : [ 5]}}""" + suffix
+    Venue.where(_.legacyid eqs 1).modify(_.popularity setTo None)         .toString() must_== query + """{ "$unset" : { "popularity" : 1}}""" + suffix
     Venue.where(_.legacyid eqs 1).modify(_.popularity push 5)             .toString() must_== query + """{ "$push" : { "popularity" : 5}}""" + suffix
     Venue.where(_.legacyid eqs 1).modify(_.tags pushAll List("a", "b"))   .toString() must_== query + """{ "$pushAll" : { "tags" : [ "a" , "b"]}}""" + suffix
     Venue.where(_.legacyid eqs 1).modify(_.tags addToSet "a")             .toString() must_== query + """{ "$addToSet" : { "tags" : "a"}}""" + suffix


### PR DESCRIPTION
This enables modify clauses for the form
`.modify(_.fooList setTo someOptionalList)`, where `Some(list)` will
set the field to `list` and `None` will unset the field. Rogue already
supports on this pattern on `AbstractModifyField`.

Note that this change required annotating integer literals in
`QueryTest.scala` as being of type `Long`, as it seems to break the
implicit conversion for widening `Int` to `Long` in the query. I have no
opinion on whether the enhanced functionality in this patch justifies
the break in backwards compatibility.