### PR TITLE
Text index support

### DIFF
--- a/fig.yml
+++ b/fig.yml
@@ -1,0 +1,5 @@
+mongo:
+  image: dockerfile/mongodb
+  command: "/usr/bin/mongod --noprealloc --smallfiles"
+  ports:
+    - "37648:27017"

--- a/rogue-core/src/main/scala/com/foursquare/rogue/MongoHelpers.scala
+++ b/rogue-core/src/main/scala/com/foursquare/rogue/MongoHelpers.scala
@@ -7,7 +7,7 @@ import scala.collection.immutable.ListMap
 
 object MongoHelpers extends Rogue {
   case class AndCondition(clauses: List[QueryClause[_]], orCondition: Option[OrCondition], searchCondition: Option[SearchCondition]) {
-    def isEmpty: Boolean = clauses.isEmpty && orCondition.isEmpty
+    def isEmpty: Boolean = clauses.isEmpty && orCondition.isEmpty && searchCondition.isEmpty
   }
 
   case class OrCondition(conditions: List[AndCondition])

--- a/rogue-core/src/main/scala/com/foursquare/rogue/PhantomTypes.scala
+++ b/rogue-core/src/main/scala/com/foursquare/rogue/PhantomTypes.scala
@@ -35,39 +35,61 @@ sealed trait ShardKeySpecified extends ShardAware
 sealed trait AllShardsOk extends ShardAware
 sealed trait Sh extends ShardKeyNotSpecified with ShardKeySpecified with AllShardsOk
 
+sealed trait HasSearchClause
+sealed trait HasNoSearchClause
+sealed trait Sr extends HasSearchClause with HasNoSearchClause
+
 @implicitNotFound(msg = "Query must be Unordered, but it's actually ${In}")
 trait AddOrder[-In, +Out] extends Required[In, Unordered]
 object AddOrder {
-  implicit def addOrder[Rest >: Sel with Lim with Sk with Or with Sh]: AddOrder[Rest with Unordered, Rest with Ordered] = null
+  implicit def addOrder[Rest >: Sel with Lim with Sk with Or with Sh with Sr]: AddOrder[Rest with Unordered, Rest with Ordered] = null
+}
+
+@implicitNotFound(msg = "Query must be Unordered with HasNoSearchClause, but it's actually ${In}")
+trait AddNaturalOrder[-In, +Out] extends Required[In, Unordered with HasNoSearchClause]
+object AddNaturalOrder {
+  implicit def addOrder[Rest >: Sel with Lim with Sk with Or with Sh with Sr]: AddNaturalOrder[Rest with Unordered with HasNoSearchClause, Rest with Ordered with HasNoSearchClause] = null
+}
+
+@implicitNotFound(msg = "Query must be Unordered with HasSearchClause, but it's actually ${In}")
+trait AddScoreOrder[-In, +Out] extends Required[In, Unordered with HasSearchClause]
+object AddScoreOrder {
+  implicit def addScoreOrder[Rest >: Sel with Lim with Sk with Or with Sh with Sr]: AddScoreOrder[Rest with Unordered with HasSearchClause, Rest with Ordered with HasSearchClause] = null
 }
 
 @implicitNotFound(msg = "Query must be Unselected, but it's actually ${In}")
 trait AddSelect[-In, +Out, +One] extends Required[In, Unselected]
 object AddSelect {
-  implicit def addSelect[Rest >: Ord with Lim with Sk with Or with Sh]: AddSelect[Rest with Unselected, Rest with Selected, Rest with SelectedOne] = null
+  implicit def addSelect[Rest >: Ord with Lim with Sk with Or with Sh with Sr]: AddSelect[Rest with Unselected, Rest with Selected, Rest with SelectedOne] = null
 }
 
 @implicitNotFound(msg = "Query must be Unlimited, but it's actually ${In}")
 trait AddLimit[-In, +Out] extends Required[In, Unlimited]
 object AddLimit {
-  implicit def addLimit[Rest >: Ord with Sel with Sk with Or with Sh]: AddLimit[Rest with Unlimited, Rest with Limited] = null
+  implicit def addLimit[Rest >: Ord with Sel with Sk with Or with Sh with Sr]: AddLimit[Rest with Unlimited, Rest with Limited] = null
 }
 
 @implicitNotFound(msg = "Query must be Unskipped, but it's actually ${In}")
 trait AddSkip[-In, +Out] extends Required[In, Unskipped]
 object AddSkip {
-  implicit def addSkip[Rest >: Ord with Sel with Lim with Or with Sh]: AddSkip[Rest with Unskipped, Rest with Skipped] = null
+  implicit def addSkip[Rest >: Ord with Sel with Lim with Or with Sh with Sr]: AddSkip[Rest with Unskipped, Rest with Skipped] = null
+}
+
+@implicitNotFound(msg = "Query must be HasNoSearchClause, but it's actually ${In}")
+trait AddText[-In, +Out] extends Required[In, HasNoSearchClause]
+object AddText {
+  implicit def addText[Rest >: Ord with Sel with Lim with Sk with Or with Sh]: AddText[Rest with HasNoSearchClause, Rest with HasSearchClause] = null
 }
 
 @implicitNotFound(msg = "Query must be HasNoOrClause, but it's actually ${In}")
 trait AddOrClause[-In, +Out] extends Required[In, HasNoOrClause]
 object AddOrClause {
-  implicit def addOrClause[Rest >: Ord with Sel with Lim with Sk with Sh]: AddOrClause[Rest with HasNoOrClause, Rest with HasOrClause] = null
+  implicit def addOrClause[Rest >: Ord with Sel with Lim with Sk with Sh with Sr]: AddOrClause[Rest with HasNoOrClause, Rest with HasOrClause] = null
 }
 
 trait AddShardAware[-In, +Specified, +AllOk] extends Required[In, ShardKeyNotSpecified]
 object AddShardAware {
-  implicit def addShardAware[Rest >: Ord with Sel with Lim with Sk with Or]: AddShardAware[Rest with ShardKeyNotSpecified, Rest with ShardKeySpecified, Rest with AllShardsOk] = null
+  implicit def addShardAware[Rest >: Ord with Sel with Lim with Sk with Or with Sr]: AddShardAware[Rest with ShardKeyNotSpecified, Rest with ShardKeySpecified, Rest with AllShardsOk] = null
 }
 
 @implicitNotFound(msg = "In order to call this method, ${A} must NOT be a subclass of ${B}.")
@@ -111,12 +133,14 @@ sealed trait Index extends Indexable with IndexScannable
 sealed trait PartialIndexScan extends IndexScannable
 sealed trait IndexScan extends IndexScannable
 sealed trait DocumentScan extends MaybeIndexed
+sealed trait TextIndex extends Indexable
 
 case object NoIndexInfo extends NoIndexInfo
 case object Index extends Index
 case object PartialIndexScan extends PartialIndexScan
 case object IndexScan extends IndexScan
 case object DocumentScan extends DocumentScan
+case object TextIndex extends TextIndex
 
 sealed trait MaybeUsedIndex
 sealed trait UsedIndex extends MaybeUsedIndex

--- a/rogue-core/src/main/scala/com/foursquare/rogue/Query.scala
+++ b/rogue-core/src/main/scala/com/foursquare/rogue/Query.scala
@@ -144,10 +144,10 @@ case class Query[M, R, +State](
    * you can see that the "MaybeHasOrClause" type parameter is changed, and is now specifically
    * bound to "HasOrClause", rather than to a type variable.</p>
    */
-  def or[S2](subqueries: (Query[M, R, Ordered with Selected with Limited with Skipped with HasNoOrClause] => Query[M, R, _])*)
+  def or[S2](subqueries: (Query[M, R, Ordered with Selected with Limited with Skipped with HasNoOrClause with HasNoSearchClause] => Query[M, R, _])*)
             (implicit ev: AddOrClause[State, S2]): Query[M, R, S2] = {
     val queryBuilder =
-      this.copy[M, R, Ordered with Selected with Limited with Skipped with HasNoOrClause](
+      this.copy[M, R, Ordered with Selected with Limited with Skipped with HasNoOrClause with HasNoSearchClause](
         lim = None,
         sk = None,
         maxScan = None,

--- a/rogue-core/src/main/scala/com/foursquare/rogue/QueryClause.scala
+++ b/rogue-core/src/main/scala/com/foursquare/rogue/QueryClause.scala
@@ -179,7 +179,7 @@ case class ElemMatchWithPredicateClause[V](override val fieldName: String, claus
   override def extend(q: BasicDBObjectBuilder, signature: Boolean): Unit = {
     import com.foursquare.rogue.MongoHelpers.AndCondition
     val nested = q.push("$elemMatch")
-    MongoHelpers.MongoBuilder.buildCondition(AndCondition(clauses.toList, None), nested, signature)
+    MongoHelpers.MongoBuilder.buildCondition(AndCondition(clauses.toList, None, None), nested, signature)
     nested.pop
   }
   override def withExpectedIndexBehavior(b: MaybeIndexed): ElemMatchWithPredicateClause[V] = this.copy(expectedIndexBehavior = b)
@@ -228,7 +228,7 @@ class ModifyPullWithPredicateClause[V](fieldName: String, clauses: Seq[QueryClau
     extends ModifyClause(ModOps.Pull) {
   override def extend(q: BasicDBObjectBuilder): Unit = {
     import com.foursquare.rogue.MongoHelpers.AndCondition
-    MongoHelpers.MongoBuilder.buildCondition(AndCondition(clauses.toList, None), q, false)
+    MongoHelpers.MongoBuilder.buildCondition(AndCondition(clauses.toList, None, None), q, false)
   }
 }
 
@@ -237,7 +237,7 @@ class ModifyPullObjWithPredicateClause[V](fieldName: String, clauses: Seq[QueryC
   override def extend(q: BasicDBObjectBuilder): Unit = {
     import com.foursquare.rogue.MongoHelpers.AndCondition
     val nested = q.push(fieldName)
-    MongoHelpers.MongoBuilder.buildCondition(AndCondition(clauses.toList, None), nested, false)
+    MongoHelpers.MongoBuilder.buildCondition(AndCondition(clauses.toList, None, None), nested, false)
     nested.pop
   }
 }

--- a/rogue-core/src/main/scala/com/foursquare/rogue/package.scala
+++ b/rogue-core/src/main/scala/com/foursquare/rogue/package.scala
@@ -4,8 +4,8 @@ package com.foursquare
 
 package object rogue {
 
-  type InitialState = Unordered with Unselected with Unlimited with Unskipped with HasNoOrClause with ShardKeyNotSpecified
-  type OrderedState = Ordered with Unselected with Unlimited with Unskipped with HasNoOrClause with ShardKeyNotSpecified
+  type InitialState = Unordered with Unselected with Unlimited with Unskipped with HasNoOrClause with ShardKeyNotSpecified with HasNoSearchClause
+  type OrderedState = Ordered with Unselected with Unlimited with Unskipped with HasNoOrClause with ShardKeyNotSpecified with HasNoSearchClause
 
   type SimpleQuery[M] = Query[M, M, InitialState]
   type OrderedQuery[M] = Query[M, M, OrderedState]

--- a/rogue-core/src/test/scala/com/foursquare/rogue/TrivialORMQueryTest.scala
+++ b/rogue-core/src/test/scala/com/foursquare/rogue/TrivialORMQueryTest.scala
@@ -52,13 +52,13 @@ object TrivialORM {
       select: Option[MongoSelect[M, R]]
     ): RogueSerializer[R] = new RogueSerializer[R] {
       override def fromDBObject(dbo: DBObject): R = select match {
-        case Some(MongoSelect(Nil, transformer)) =>
+        case Some(MongoSelect(Nil, transformer, true, _)) =>
           // A MongoSelect clause exists, but has empty fields. Return null.
           // This is used for .exists(), where we just want to check the number
           // of returned results is > 0.
           transformer(null)
 
-        case Some(MongoSelect(fields, transformer)) =>
+        case Some(MongoSelect(fields, transformer, _, _)) =>
           transformer(fields.map(f => f.valueOrDefault(Option(dbo.get(f.field.name)))))
 
         case None =>
@@ -70,7 +70,7 @@ object TrivialORM {
   object Implicits extends Rogue {
     implicit def meta2Query[M <: Meta[R], R](meta: M with Meta[R]): Query[M, R, InitialState] = {
       Query[M, R, InitialState](
-        meta, meta.collectionName, None, None, None, None, None, AndCondition(Nil, None), None, None, None)
+        meta, meta.collectionName, None, None, None, None, None, AndCondition(Nil, None, None), None, None, None)
     }
   }
 }

--- a/rogue-index/src/main/scala/com/foursquare/index/IndexedRecord.scala
+++ b/rogue-index/src/main/scala/com/foursquare/index/IndexedRecord.scala
@@ -8,4 +8,5 @@ package com.foursquare.index
  */
 trait IndexedRecord[M] {
   val mongoIndexList: List[MongoIndex[_]] = List()
+  val mongoTextIndex: Option[MongoTextIndex[_]] = None
 }

--- a/rogue-index/src/main/scala/com/foursquare/index/MongoIndex.scala
+++ b/rogue-index/src/main/scala/com/foursquare/index/MongoIndex.scala
@@ -116,7 +116,7 @@ case class IndexBuilder[M](rec: M) {
       m1: IndexModifier,
       f2: M => Field[_, M],
       m2: IndexModifier
-  ): MongoIndex2[M] = 
+  ): MongoIndex2[M] =
     MongoIndex2[M](f1(rec), m1, f2(rec), m2)
 
   def index(
@@ -170,4 +170,111 @@ case class IndexBuilder[M](rec: M) {
       m6: IndexModifier
   ): MongoIndex6[M] =
     MongoIndex6[M](f1(rec), m1, f2(rec), m2, f3(rec), m3, f4(rec), m4, f5(rec), m5, f6(rec), m6)
+}
+
+trait MongoTextIndex[R] extends UntypedMongoIndex
+
+case class MongoTextIndexAll[R]() extends MongoTextIndex[R] {
+  def asListMap = ListMap(("$**", "text"))
+}
+
+case class MongoTextIndex1[R](
+    f1: Field[_, R]
+) extends MongoTextIndex[R] {
+  def asListMap = ListMap((f1.name, "text"))
+}
+
+case class MongoTextIndex2[R](
+    f1: Field[_, R],
+    f2: Field[_, R]
+) extends MongoTextIndex[R] {
+  def asListMap = ListMap((f1.name, "text"), (f2.name, "text"))
+}
+
+case class MongoTextIndex3[R](
+    f1: Field[_, R],
+    f2: Field[_, R],
+    f3: Field[_, R]
+) extends MongoTextIndex[R] {
+  def asListMap = ListMap((f1.name, "text"), (f2.name, "text"), (f3.name, "text"))
+}
+
+case class MongoTextIndex4[R](
+    f1: Field[_, R],
+    f2: Field[_, R],
+    f3: Field[_, R],
+    f4: Field[_, R]
+) extends MongoTextIndex[R] {
+  def asListMap = ListMap((f1.name, "text"), (f2.name, "text"), (f3.name, "text"), (f4.name, "text"))
+}
+
+case class MongoTextIndex5[R](
+    f1: Field[_, R],
+    f2: Field[_, R],
+    f3: Field[_, R],
+    f4: Field[_, R],
+    f5: Field[_, R]
+) extends MongoTextIndex[R] {
+  def asListMap = ListMap((f1.name, "text"), (f2.name, "text"), (f3.name, "text"), (f4.name, "text"), (f5.name, "text"))
+}
+
+case class MongoTextIndex6[R](
+    f1: Field[_, R],
+    f2: Field[_, R],
+    f3: Field[_, R],
+    f4: Field[_, R],
+    f5: Field[_, R],
+    f6: Field[_, R]
+) extends MongoTextIndex[R] {
+  def asListMap = ListMap((f1.name, "text"), (f2.name, "text"), (f3.name, "text"), (f4.name, "text"), (f5.name, "text"), (f6.name, "text"))
+}
+
+case class TextIndexBuilder[M](rec: M) {
+  def textIndex(): MongoTextIndexAll[M] =
+    MongoTextIndexAll[M]()
+
+  def textIndex(
+      f1: M => Field[_, M]
+  ): MongoTextIndex1[M] =
+    MongoTextIndex1[M](f1(rec))
+
+  def textIndex(
+      f1: M => Field[_, M],
+      f2: M => Field[_, M]
+  ): MongoTextIndex2[M] =
+    MongoTextIndex2[M](f1(rec), f2(rec))
+
+  def textIndex(
+      f1: M => Field[_, M],
+      f2: M => Field[_, M],
+      f3: M => Field[_, M]
+  ): MongoTextIndex3[M] =
+    MongoTextIndex3[M](f1(rec), f2(rec), f3(rec))
+
+  def textIndex(
+      f1: M => Field[_, M],
+      f2: M => Field[_, M],
+      f3: M => Field[_, M],
+      f4: M => Field[_, M]
+  ): MongoTextIndex4[M] =
+    MongoTextIndex4[M](f1(rec), f2(rec), f3(rec), f4(rec))
+
+  def textIndex(
+      f1: M => Field[_, M],
+      f2: M => Field[_, M],
+      f3: M => Field[_, M],
+      f4: M => Field[_, M],
+      f5: M => Field[_, M]
+  ): MongoTextIndex5[M] =
+    MongoTextIndex5[M](f1(rec), f2(rec), f3(rec), f4(rec), f5(rec))
+
+  def textIndex(
+      f1: M => Field[_, M],
+      f2: M => Field[_, M],
+      f3: M => Field[_, M],
+      f4: M => Field[_, M],
+      f5: M => Field[_, M],
+      f6: M => Field[_, M]
+  ): MongoTextIndex6[M] =
+    MongoTextIndex6[M](f1(rec), f2(rec), f3(rec), f4(rec), f5(rec), f6(rec))
 }

--- a/rogue-lift/src/main/scala/com/foursquare/rogue/ExecutableQuery.scala
+++ b/rogue-lift/src/main/scala/com/foursquare/rogue/ExecutableQuery.scala
@@ -37,7 +37,7 @@ case class ExecutableQuery[MB, M <: MB, R, State](
    * Checks if there are any records that match this query.
    */
   def exists()(implicit ev: State <:< Unlimited with Unskipped): Boolean = {
-    val q = query.copy(select = Some(MongoSelect[M, Null](Nil, _ => null)))
+    val q = query.copy(select = Some(MongoSelect[M, Null](Nil, _ => null, true, query.select.flatMap(_.scoreName))))
     db.fetch(q.limit(1)).size > 0
   }
 

--- a/rogue-lift/src/main/scala/com/foursquare/rogue/LiftQueryExecutor.scala
+++ b/rogue-lift/src/main/scala/com/foursquare/rogue/LiftQueryExecutor.scala
@@ -59,12 +59,12 @@ class LiftQueryExecutor(override val adapter: MongoJavaDriverAdapter[MongoRecord
   ): RogueSerializer[R] = {
     new RogueSerializer[R] {
       override def fromDBObject(dbo: DBObject): R = select match {
-        case Some(MongoSelect(Nil, transformer)) =>
+        case Some(MongoSelect(Nil, transformer, true, _)) =>
           // A MongoSelect clause exists, but has empty fields. Return null.
           // This is used for .exists(), where we just want to check the number
           // of returned results is > 0.
           transformer(null)
-        case Some(MongoSelect(fields, transformer)) =>
+        case Some(MongoSelect(fields, transformer, _, _)) =>
           val inst = meta.createRecord.asInstanceOf[MongoRecord[_]]
 
           LiftQueryExecutorHelpers.setInstanceFieldFromDbo(inst, dbo, "_id")

--- a/rogue-lift/src/main/scala/com/foursquare/rogue/LiftRogue.scala
+++ b/rogue-lift/src/main/scala/com/foursquare/rogue/LiftRogue.scala
@@ -6,7 +6,7 @@ import com.foursquare.field.{
     Field => RField,
     OptionalField => ROptionalField,
     RequiredField => RRequiredField}
-import com.foursquare.index.IndexBuilder
+import com.foursquare.index.{IndexBuilder, TextIndexBuilder}
 import com.foursquare.rogue.MongoHelpers.{AndCondition, MongoModify}
 import java.util.Date
 import net.liftweb.json.JsonAST.{JArray, JInt}
@@ -28,7 +28,7 @@ trait LiftRogue extends Rogue {
         val orCondition = QueryHelpers.orConditionFromQueries(q :: qs)
         Query[M, R, Unordered with Unselected with Unlimited with Unskipped with HasOrClause](
           q.meta, q.collectionName, None, None, None, None, None,
-          AndCondition(Nil, Some(orCondition)), None, None, None)
+          AndCondition(Nil, Some(orCondition), None), None, None, None)
       }
     }
   }
@@ -39,10 +39,13 @@ trait LiftRogue extends Rogue {
   implicit def metaRecordToQueryBuilder[M <: MongoRecord[M]]
       (rec: M with MongoMetaRecord[M]): Query[M, M, InitialState] =
     Query[M, M, InitialState](
-      rec, rec.collectionName, None, None, None, None, None, AndCondition(Nil, None), None, None, None)
+      rec, rec.collectionName, None, None, None, None, None, AndCondition(Nil, None, None), None, None, None)
 
   implicit def metaRecordToIndexBuilder[M <: MongoRecord[M]](rec: M with MongoMetaRecord[M]): IndexBuilder[M] =
       IndexBuilder(rec)
+
+  implicit def metaRecordToTextIndexBuilder[M <: MongoRecord[M]](rec: M with MongoMetaRecord[M]): TextIndexBuilder[M] =
+      TextIndexBuilder(rec)
 
   implicit def queryToLiftQuery[M <: MongoRecord[_], R, State]
     (query: Query[M, R, State])

--- a/rogue-lift/src/test/scala/com/foursquare/rogue/EndToEndTest.scala
+++ b/rogue-lift/src/test/scala/com/foursquare/rogue/EndToEndTest.scala
@@ -388,4 +388,23 @@ class EndToEndTest extends JUnitMustMatchers {
     Venue.select(_.tags.slice(-2)).get() must_== Some(List("3", "4"))
     Venue.select(_.tags.slice(1, 2)).get() must_== Some(List("2", "3"))
   }
+
+  @Test
+  def testSearch {
+    import net.liftweb.json.JsonDSL._
+    Venue.createIndex(("venuename" -> "text"))
+    baseTestVenue().legacyid(99).save(true)
+    baseTestVenue().venuename("test venue two").save(true)
+    baseTestVenue().venuename("venue three").save(true)
+
+    Venue.search("venue").select(_.venuename).orderScore().count() must_== 3
+    Venue.search("venue -test").count() must_== 1
+    Venue.search(""" "test venue" """).count() must_== 2
+    Venue.search(""" "test venue" -two """).count() must_== 1
+    Venue.where(_.legacyid eqs 123).search("venue").count() must_== 2
+    Venue.search("aaa").count() must_== 0
+
+    Venue.search("venue").exists() must beTrue
+    Venue.search("aaa").exists() must beFalse
+  }
 }

--- a/rogue-lift/src/test/scala/com/foursquare/rogue/QueryTest.scala
+++ b/rogue-lift/src/test/scala/com/foursquare/rogue/QueryTest.scala
@@ -439,6 +439,7 @@ class QueryTest extends JUnitMustMatchers {
     Venue.where(_.mayor eqs 1).search("Starbucks").signature() must_== """db.venues.find({ "mayor" : 0 , "$text" : { "$search" : "Starbucks"}})"""
     Venue.search("Starbucks", None).signature() must_== """db.venues.find({ "$text" : { "$search" : "Starbucks"}})"""
     Venue.search("Starbucks", Some("es")).signature() must_== """db.venues.find({ "$text" : { "$search" : "Starbucks" , "$language" : "es"}})"""
+    Venue.where(_.mayor eqs 1).or(_.where(_._id eqs oid), _.search("Starbucks")).signature() must_== """db.venues.find({ "mayor" : 0 , "$or" : [ { "_id" : 0} , { "$text" : { "$search" : "Starbucks"}}]})"""
   }
 
   @Test

--- a/rogue-lift/src/test/scala/com/foursquare/rogue/QueryTest.scala
+++ b/rogue-lift/src/test/scala/com/foursquare/rogue/QueryTest.scala
@@ -234,6 +234,21 @@ class QueryTest extends JUnitMustMatchers {
     Venue.scan(_.mayor eqs 1).not(_.mayor_count lt 5).toString() must_== """db.venues.find({ "mayor" : 1 , "mayor_count" : { "$not" : { "$lt" : 5}}})"""
     Venue.scan(_.mayor eqs 1).not(_.mayor_count lt 5).not(_.mayor_count gt 6).toString() must_== """db.venues.find({ "mayor" : 1 , "mayor_count" : { "$not" : { "$gt" : 6 , "$lt" : 5}}})"""
     Venue.scan(_.mayor eqs 1).not(_.mayor_count lt 5).and(_.mayor_count gt 3).toString() must_== """db.venues.find({ "mayor" : 1 , "mayor_count" : { "$gt" : 3 , "$not" : { "$lt" : 5}}})"""
+
+    // text search
+    Venue.search("Starbucks").toString() must_== """db.venues.find({ "$text" : { "$search" : "Starbucks"}})"""
+    Venue.where(_.mayor eqs 1).search("Starbucks").toString() must_== """db.venues.find({ "mayor" : 1 , "$text" : { "$search" : "Starbucks"}})"""
+    Venue.search("Starbucks", None).toString() must_== """db.venues.find({ "$text" : { "$search" : "Starbucks"}})"""
+    Venue.search("Starbucks", Some("es")).toString() must_== """db.venues.find({ "$text" : { "$search" : "Starbucks" , "$language" : "es"}})"""
+
+    // ordered text search
+    Venue.search("Starbucks").orderScore().toString() must_== """db.venues.find({ "$text" : { "$search" : "Starbucks"}}, { "score" : { "$meta" : "textScore"}}).sort({ "score" : { "$meta" : "textScore"}})"""
+    Venue.search("Starbucks").orderScore().select(_.mayor).toString() must_== """db.venues.find({ "$text" : { "$search" : "Starbucks"}}, { "mayor" : 1 , "score" : { "$meta" : "textScore"}}).sort({ "score" : { "$meta" : "textScore"}})"""
+    Venue.search("Starbucks").select(_.mayor).orderScore().toString() must_== """db.venues.find({ "$text" : { "$search" : "Starbucks"}}, { "mayor" : 1 , "score" : { "$meta" : "textScore"}}).sort({ "score" : { "$meta" : "textScore"}})"""
+    Venue.search("Starbucks").orderScore("searchScore").toString() must_== """db.venues.find({ "$text" : { "$search" : "Starbucks"}}, { "searchScore" : { "$meta" : "textScore"}}).sort({ "searchScore" : { "$meta" : "textScore"}})"""
+
+    Venue.search("Starbucks").orderAsc(_.venuename).andScore().toString() must_== """db.venues.find({ "$text" : { "$search" : "Starbucks"}}, { "score" : { "$meta" : "textScore"}}).sort({ "venuename" : 1 , "score" : { "$meta" : "textScore"}})"""
+    Venue.search("Starbucks").orderAsc(_.venuename).andScore("searchScore").toString() must_== """db.venues.find({ "$text" : { "$search" : "Starbucks"}}, { "searchScore" : { "$meta" : "textScore"}}).sort({ "venuename" : 1 , "searchScore" : { "$meta" : "textScore"}})"""
   }
 
   @Test
@@ -418,6 +433,12 @@ class QueryTest extends JUnitMustMatchers {
 
     // or queries
     Venue.where(_.mayor eqs 1).or(_.where(_._id eqs oid)).signature() must_== """db.venues.find({ "mayor" : 0 , "$or" : [ { "_id" : 0}]})"""
+
+    // text search
+    Venue.search("Starbucks").signature() must_== """db.venues.find({ "$text" : { "$search" : "Starbucks"}})"""
+    Venue.where(_.mayor eqs 1).search("Starbucks").signature() must_== """db.venues.find({ "mayor" : 0 , "$text" : { "$search" : "Starbucks"}})"""
+    Venue.search("Starbucks", None).signature() must_== """db.venues.find({ "$text" : { "$search" : "Starbucks"}})"""
+    Venue.search("Starbucks", Some("es")).signature() must_== """db.venues.find({ "$text" : { "$search" : "Starbucks" , "$language" : "es"}})"""
   }
 
   @Test
@@ -569,6 +590,13 @@ class QueryTest extends JUnitMustMatchers {
     q.modifyOpt(noId)(_.legacyid setTo _).toString() must_== prefix + """{ }""" + suffix
     q.modifyOpt(someEnum)(_.status setTo _).toString() must_== prefix + """{ "$set" : { "status" : "Open"}}""" + suffix
     q.modifyOpt(noEnum)(_.status setTo _).toString() must_== prefix + """{ }""" + suffix
+
+    // searchOpt
+    Venue.searchOpt(Some("Starbucks")).toString() must_== """db.venues.find({ "$text" : { "$search" : "Starbucks"}})"""
+    Venue.searchOpt(Some("Starbucks"), None).toString() must_== """db.venues.find({ "$text" : { "$search" : "Starbucks"}})"""
+    Venue.searchOpt(Some("Starbucks"), Some("es")).toString() must_== """db.venues.find({ "$text" : { "$search" : "Starbucks" , "$language" : "es"}})"""
+    Venue.searchOpt(None, None).toString() must_== """db.venues.find({ })"""
+    Venue.searchOpt(None, Some("es")).toString() must_== """db.venues.find({ })"""
   }
 
   @Test
@@ -683,6 +711,13 @@ class QueryTest extends JUnitMustMatchers {
     check("""Venue.limit(1) get()""")
     check("""Venue.skip(3).skip(3)""")
     check("""Venue.select(_.legacyid).select(_.closed)""")
+    check("""Venue.search("Starbucks").search("Starbucks")""")
+    check("""Venue.search("Starbucks").orderScore().orderAsc(_.legacyid)""")
+    check("""Venue.search("Starbucks").orderAsc(_.legacyid).orderScore()""")
+    check("""Venue.orderScore()""")
+    check("""Venue.orderDesc(_.venuename).andScore()""")
+    check("""Venue.andScore()""")
+    check("""Venue.search("Starbucks").orderNaturalAsc""")
 
     // select case class
     check("""Venue.selectCase(_.legacyid, V2)""")

--- a/rogue-lift/src/test/scala/com/foursquare/rogue/TestModels.scala
+++ b/rogue-lift/src/test/scala/com/foursquare/rogue/TestModels.scala
@@ -69,6 +69,9 @@ object Venue extends Venue with MongoMetaRecord[Venue] {
   val geoCustomIdx = Venue.index(_.geolatlng, CustomIndex, _.tags, Asc)
   override val mongoIndexList = List(idIdx, mayorIdIdx, mayorIdClosedIdx, legIdx, geoIdx, geoCustomIdx)
 
+  val textIdx = Venue.textIndex(_.venuename)
+  override val mongoTextIndex = Some(textIdx)
+
   trait FK[T <: FK[T]] extends MongoRecord[T] {
     self: T=>
     object venueid extends ObjectIdField[T](this) with HasMongoForeignObjectId[Venue] {


### PR DESCRIPTION
This adds basic support for text search with mongo's text index.

Notes:

- Using `orderScore()` or `andScore()` will automatically add the corresponding term to the select element

Not implemented

- search clause in an `or` clause
- IndexChecker


[Restrictions](http://docs.mongodb.org/manual/reference/operator/query/text/#restrictions) implemented:

- [x] A query can specify, at most, one $text expression.
- [ ] The $text query can not appear in $nor expressions.
- [ ] To use a $text query in an $or expression, all clauses in the $or array must be indexed.
- [ ] You cannot use hint() if the query includes a $text query expression.
- [x] You cannot specify $natural sort order if the query includes a $text expression.
- [ ] You cannot combine the $text expression, which requires a special text index, with a query operator that requires a different type of special index. For example you cannot combine $text expression with the $near operator.
