### PR TITLE
SpindleDatabaseService has overridable serializer

### DIFF
--- a/rogue-spindle/src/main/scala/com/foursquare/rogue/spindle/SpindleDBDecoderFactory.scala
+++ b/rogue-spindle/src/main/scala/com/foursquare/rogue/spindle/SpindleDBDecoderFactory.scala
@@ -1,0 +1,77 @@
+// Copyright 2015 Foursquare Labs Inc. All Rights Reserved.
+
+package com.foursquare.rogue.spindle
+
+import com.foursquare.spindle.{UntypedMetaRecord, UntypedRecord}
+import com.mongodb.{BasicDBObject, DBCursor, DBCallback, DBCollection, DBDecoder, DBDecoderFactory, DBObject}
+import java.io.InputStream
+import org.bson.{BasicBSONDecoder, BSONCallback, BSONObject}
+
+case class SpindleDBDecoderFactory(
+  meta: UntypedMetaRecord,
+  recordReader: (UntypedMetaRecord, InputStream) => SpindleDBObject
+) extends DBDecoderFactory {
+  def create(): DBDecoder = new SpindleDBDecoder(meta, recordReader)
+}
+
+case class SpindleDBDecoder(
+  meta: UntypedMetaRecord,
+  recordReader: (UntypedMetaRecord, InputStream) => SpindleDBObject
+) extends DBDecoder {
+  def decode(is: InputStream, collection: DBCollection): DBObject = {
+    recordReader(meta, is)
+  }
+
+  def getDBCallback(collection: DBCollection): DBCallback = {
+    throw new UnsupportedOperationException()
+  }
+  def decode(bytes: Array[Byte], collection: DBCollection): DBObject = {
+    throw new UnsupportedOperationException()
+  }
+  def readObject(bytes: Array[Byte]): BSONObject = {
+    throw new UnsupportedOperationException()
+  }
+  def readObject(in: InputStream): BSONObject = {
+    throw new UnsupportedOperationException()
+  }
+  def decode(bytes: Array[Byte], callback: BSONCallback): Int = {
+    throw new UnsupportedOperationException()
+  }
+  def decode(in: InputStream, callback: BSONCallback): Int = {
+    throw new UnsupportedOperationException()
+  }
+}
+
+trait SpindleDBObject extends DBObject {
+  def record: UntypedRecord
+  override def isPartialObject(): Boolean = false
+
+  override def put(key: String, dv: Object): Object = throw new UnsupportedOperationException()
+  override def putAll(o: BSONObject): Unit = throw new UnsupportedOperationException()
+  override def putAll(m: java.util.Map[_, _]): Unit = throw new UnsupportedOperationException()
+  override def toMap(): java.util.Map[_, _] = throw new UnsupportedOperationException()
+  override def removeField(key: String): Object = throw new UnsupportedOperationException()
+  override def containsKey(s: String): Boolean = throw new UnsupportedOperationException()
+  override def containsField(s: String): Boolean = throw new UnsupportedOperationException()
+  override def keySet(): java.util.Set[String] = throw new UnsupportedOperationException()
+}
+
+case class SpindleNativeDBObject(record: UntypedRecord, errorMessage: String, code: Int) extends SpindleDBObject {
+  override def markAsPartialObject(): Unit = {}
+  override def get(key: String): Object = {
+    if ("$err" == key) {
+      errorMessage
+    } else if ("code" == key) {
+      code: java.lang.Integer
+    } else {
+      null
+    }
+  }
+}
+
+case class SpindleMongoDBObject(record: UntypedRecord, dbo: DBObject) extends SpindleDBObject {
+  override def markAsPartialObject(): Unit = {
+    dbo.markAsPartialObject()
+  }
+  override def get(key: String): Object = dbo.get(key)
+}

--- a/rogue-spindle/src/main/scala/com/foursquare/rogue/spindle/SpindleDatabaseService.scala
+++ b/rogue-spindle/src/main/scala/com/foursquare/rogue/spindle/SpindleDatabaseService.scala
@@ -2,19 +2,43 @@
 
 package com.foursquare.rogue.spindle
 
+import com.foursquare.common.thrift.bson.TBSONObjectProtocol
 import com.foursquare.rogue.{DBCollectionFactory, MongoJavaDriverAdapter, QueryExecutor, QueryOptimizer}
 import com.foursquare.spindle.{UntypedMetaRecord, UntypedRecord}
 import com.foursquare.rogue.MongoHelpers.MongoSelect
-import com.mongodb.WriteConcern
+import com.mongodb.{DefaultDBDecoder, DBObject, WriteConcern}
+import java.io.InputStream
+
 
 class SpindleDatabaseService(val dbCollectionFactory: SpindleDBCollectionFactory) extends QueryExecutor[UntypedMetaRecord, UntypedRecord] {
   override def readSerializer[M <: UntypedMetaRecord, R](meta: M, select: Option[MongoSelect[M, R]]):
       SpindleRogueReadSerializer[M, R] = {
     new SpindleRogueReadSerializer(meta, select)
   }
+
   override def writeSerializer(record: UntypedRecord): SpindleRogueWriteSerializer = new SpindleRogueWriteSerializer
   override def defaultWriteConcern: WriteConcern = WriteConcern.SAFE
-  override val adapter: MongoJavaDriverAdapter[UntypedMetaRecord, UntypedRecord] = new MongoJavaDriverAdapter(dbCollectionFactory)
+
+  // allow this to be overriden to subsititute alternative deserialization methods
+  def newBsonStreamDecoder(): (UntypedMetaRecord, InputStream) => SpindleDBObject = {
+    val decoder = new DefaultDBDecoder()
+    val protocolFactory = new TBSONObjectProtocol.ReaderFactory
+    val protocol: TBSONObjectProtocol = protocolFactory.getProtocol
+
+    (meta: UntypedMetaRecord, is: InputStream) => {
+      val record = meta.createUntypedRawRecord
+      protocol.reset()
+      val dbo: DBObject = decoder.decode(is, null)
+      protocol.setSource(dbo)
+      record.read(protocol)
+      SpindleMongoDBObject(record, dbo)
+    }
+  }
+
+  override val adapter: MongoJavaDriverAdapter[UntypedMetaRecord, UntypedRecord] = new MongoJavaDriverAdapter(
+    dbCollectionFactory,
+    (meta: UntypedMetaRecord) => SpindleDBDecoderFactory(meta, newBsonStreamDecoder())
+  )
   override val optimizer = new QueryOptimizer
 
   override def save[R <: UntypedRecord](record: R, writeConcern: WriteConcern = defaultWriteConcern): R = {

--- a/rogue-spindle/src/main/scala/com/foursquare/rogue/spindle/SpindleRogueSerializer.scala
+++ b/rogue-spindle/src/main/scala/com/foursquare/rogue/spindle/SpindleRogueSerializer.scala
@@ -28,7 +28,7 @@ class SpindleRogueReadSerializer[M <: UntypedMetaRecord, R](meta: M, select: Opt
 
   private def extractRecordFromDbo(dbo: DBObject): R = {
     dbo match {
-      case sdbo:SpindleDBObject => sdbo.record.asInstanceOf[R]
+      case sdbo: SpindleDBObject => sdbo.record.asInstanceOf[R]
       case _ =>
         val record = meta.createUntypedRawRecord
         val protocolFactory = new TBSONObjectProtocol.ReaderFactory

--- a/sbt
+++ b/sbt
@@ -6,13 +6,13 @@ INTERNAL_OPTS="-Dfile.encoding=UTF-8 -Xss8M -Xmx1G -noverify -XX:+CMSClassUnload
 # Default options, if nothing is specified
 DEFAULT_OPTS=""
 
-SBT_VERSION="0.12.0"
+SBT_VERSION="0.12.4"
 SBT_LAUNCHER="$(dirname $0)/project/sbt-launch-$SBT_VERSION.jar"
 
 if [ ! -e "$SBT_LAUNCHER" ];
 then
-    URL="http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$SBT_VERSION/sbt-launch.jar"
-    curl -o $SBT_LAUNCHER $URL
+    URL="https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch.jar"
+    curl -L -o $SBT_LAUNCHER $URL
 fi
 
 # Call with INTERNAL_OPTS followed by SBT_OPTS (or DEFAULT_OPTS). java aways takes the last option when duplicate.


### PR DESCRIPTION
Allow subclasses to use a different InputStream -> UntypedRecord

This change also reuses the TBSONObjectProtocol for each document in a
DBCursor.
